### PR TITLE
feat: add clipboard share text utilities

### DIFF
--- a/src/app/admin/sessions/page.tsx
+++ b/src/app/admin/sessions/page.tsx
@@ -1,17 +1,10 @@
 import Link from "next/link";
+import { headers } from "next/headers";
 import { getSupabase } from "@/lib/supabaseClient";
+import CopyToClipboard from "@/components/CopyToClipboard";
+import { buildShareText, type SessionRow } from "@/lib/shareText";
 
 export const dynamic = "force-dynamic";  // ⬅️ stop static prerender at build
-
-type SessionRow = {
-  id: string;
-  title: string;
-  time: string | null;
-  venue: string | null;
-  price: string | null;
-  spots_left: number | null;
-  roster: string[] | null;
-};
 
 export default async function AdminSessions() {
   const supabase = getSupabase();  // ⬅️ create client at request time
@@ -30,27 +23,42 @@ export default async function AdminSessions() {
       </main>
     );
   }
+  const hdrs = headers();
+  const proto = hdrs.get("x-forwarded-proto") ?? "http";
+  const host = hdrs.get("x-forwarded-host") ?? hdrs.get("host") ?? "localhost:3000";
+  const origin = `${proto}://${host}`;
 
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">
       <h1 className="text-2xl font-semibold mb-4">Admin — Sessions</h1>
       <ul className="space-y-3">
-        {sessions.map((s: SessionRow) => (
-          <li key={s.id} className="rounded-2xl border p-4">
-            <Link href={`/s/${s.id}`} className="block">
-              <div className="flex items-baseline justify-between">
-                <h2 className="text-lg font-medium">{s.title}</h2>
-                <span className="text-sm text-gray-600">{s.spots_left ?? 0} left</span>
-              </div>
-              <p className="text-sm text-gray-600">
-                {s.time} • {s.venue}
-              </p>
-              {s.roster?.length ? (
-                <p className="text-xs text-gray-500 mt-1">✅ {s.roster.join(", ")}</p>
-              ) : null}
-            </Link>
-          </li>
-        ))}
+        {sessions.map((s: SessionRow) => {
+          const share = buildShareText(s, origin + "/s/" + s.id);
+          return (
+            <li key={s.id} className="rounded-2xl border p-4">
+              <Link href={`/s/${s.id}`} className="block">
+                <div className="flex items-baseline justify-between">
+                  <h2 className="text-lg font-medium">{s.title}</h2>
+                  <span className="text-sm text-gray-600">{s.spots_left ?? 0} left</span>
+                </div>
+                <p className="text-sm text-gray-600">
+                  {s.time} • {s.venue}
+                </p>
+                {s.roster?.length ? (
+                  <p className="text-xs text-gray-500 mt-1">✅ {s.roster.join(", ")}</p>
+                ) : null}
+              </Link>
+              <CopyToClipboard text={share} className="mt-2" />
+              <a
+                href={"https://wa.me/?text=" + encodeURIComponent(share)}
+                target="_blank"
+                className="block mt-1 text-sm text-blue-600 underline"
+              >
+                Open in WhatsApp
+              </a>
+            </li>
+          );
+        })}
       </ul>
     </main>
   );

--- a/src/app/admin/sessions/page.tsx
+++ b/src/app/admin/sessions/page.tsx
@@ -23,7 +23,8 @@ export default async function AdminSessions() {
       </main>
     );
   }
-  const hdrs = headers();
+  //...const hdrs = headers(); //this is a promise 
+  const hdrs = await headers();  // ✅ resolve it
   const proto = hdrs.get("x-forwarded-proto") ?? "http";
   const host = hdrs.get("x-forwarded-host") ?? hdrs.get("host") ?? "localhost:3000";
   const origin = `${proto}://${host}`;

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -1,23 +1,49 @@
 "use client";
 import { useState } from "react";
 
-export default function CopyToClipboard({ text, className }: { text: string; className?: string }) {
+export default function CopyToClipboard({
+  text,
+  label = "Copy",
+  className = "",
+}: {
+  text: string;
+  label?: string;
+  className?: string;
+}) {
   const [copied, setCopied] = useState(false);
-  const onCopy = async () => {
+
+  async function onCopy() {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    } catch {
-      setCopied(false);
+    } catch (e) {
+      // fallback
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
     }
-  };
+  }
+
   return (
-    <div className={className}>
-      <textarea value={text} readOnly className="sr-only" />
-      <button onClick={onCopy} className="text-sm text-blue-600 underline">
-        {copied ? "Copied!" : "Copy"}
-      </button>
-    </div>
+    <button
+      onClick={onCopy}
+      type="button"
+      aria-label="Copy share text"
+      className={[
+        // compact “secondary” button
+        "inline-flex items-center gap-2 rounded-xl border px-3 py-1 text-sm",
+        "border-gray-300 hover:bg-gray-50 active:scale-[.99] transition",
+        className,
+      ].join(" ")}
+    >
+      <span className="i-lucide-copy w-4 h-4" aria-hidden />{/* optional icon if you have lucide */}
+      {copied ? "Copied ✓" : label}
+    </button>
   );
 }

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { useState } from "react";
+
+export default function CopyToClipboard({ text, className }: { text: string; className?: string }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+  return (
+    <div className={className}>
+      <textarea value={text} readOnly className="sr-only" />
+      <button onClick={onCopy} className="text-sm text-blue-600 underline">
+        {copied ? "Copied!" : "Copy"}
+      </button>
+    </div>
+  );
+}

--- a/src/lib/shareText.ts
+++ b/src/lib/shareText.ts
@@ -1,0 +1,20 @@
+export type SessionRow = {
+  id: string;
+  title: string;
+  time: string | null;
+  venue: string | null;
+  price: string | null;
+  spots_left: number | null;
+  roster: string[] | null;
+};
+
+export function buildShareText(session: SessionRow, url: string): string {
+  return (
+    `${session.title}\n` +
+    `Time: ${session.time ?? ""}\n` +
+    `Venue: ${session.venue ?? ""}\n` +
+    `Price: ${session.price ?? ""}\n` +
+    `Spots left: ${session.spots_left ?? 0}\n` +
+    `Join: ${url}`
+  );
+}


### PR DESCRIPTION
## Summary
- add client CopyToClipboard component for copying shareable text with feedback
- add buildShareText helper for session share messages
- show copy and WhatsApp links on admin sessions list

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab7a4d74888320ab57212fd4bd11d2