### PR TITLE
refactor: remove redundant await from headers usage

### DIFF
--- a/src/app/admin/sessions/page.tsx
+++ b/src/app/admin/sessions/page.tsx
@@ -23,8 +23,8 @@ export default async function AdminSessions() {
       </main>
     );
   }
-  //...const hdrs = headers(); //this is a promise 
-  const hdrs = await headers();  // ✅ resolve it
+  // headers() is synchronous
+  const hdrs = headers();
   const proto = hdrs.get("x-forwarded-proto") ?? "http";
   const host = hdrs.get("x-forwarded-host") ?? hdrs.get("host") ?? "localhost:3000";
   const origin = `${proto}://${host}`;

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: NextRequest) {
     );
 
     // (Optional) dynamic origin if you want to avoid APP_BASE_URL
-    const hdrs = await headers();
+    const hdrs = headers();
     const proto = hdrs.get("x-forwarded-proto") ?? "http";
     const host  = hdrs.get("x-forwarded-host") ?? hdrs.get("host") ?? "localhost:3000";
     const origin = `${proto}://${host}`;

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -11,8 +11,8 @@ export async function POST(req: Request) {
   //const sig = headers().get("stripe-signature") as string;
   //const rawBody = await req.text();
 
-  const hdrs = await headers();                            // 👈 await it
-  const sig = hdrs.get("stripe-signature") as string;      // 👈 now .get works
+  const hdrs = headers();
+  const sig = hdrs.get("stripe-signature") as string;
   const rawBody = await req.text();
 
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);


### PR DESCRIPTION
## Summary
- use synchronous `headers()` in admin sessions page
- remove unnecessary `await` from headers usage in Stripe webhook and checkout API routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac421f0b4c8320bc8c63ac7956d84a