### PR TITLE
Check Stripe webhook signature before processing

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -12,7 +12,10 @@ export async function POST(req: Request) {
   //const rawBody = await req.text();
 
   const hdrs = await headers();                            // 👈 await it
-  const sig = hdrs.get("stripe-signature") as string;      // 👈 now .get works
+  const sig = hdrs.get("stripe-signature");                // 👈 now .get works
+  if (!sig) {
+    return NextResponse.json({ error: "Missing stripe-signature" }, { status: 400 });
+  }
   const rawBody = await req.text();
 
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);


### PR DESCRIPTION
## Summary
- validate presence of `stripe-signature` header before reading the request body
- return 400 error when signature missing
- pass validated signature to `stripe.webhooks.constructEvent`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac46471e488320a6110512f2cf7e69