### PR TITLE
refactor: move session creation action

### DIFF
--- a/src/app/admin/sessions/new/actions.ts
+++ b/src/app/admin/sessions/new/actions.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { getSupabase } from "@/lib/supabaseClient";
+
+export type FormState = {
+  message: string | null;
+};
+
+export async function createSession(
+  prevState: FormState,
+  formData: FormData
+): Promise<FormState> {
+  const supabase = getSupabase();
+  const title = formData.get("title") as string;
+  const time = formData.get("time") as string;
+  const venue = formData.get("venue") as string;
+  const price = formData.get("price") as string;
+  const spots = Number(formData.get("spots"));
+  const rosterStr = (formData.get("roster") as string) || "";
+  const roster = rosterStr
+    ? rosterStr.split(",").map((s) => s.trim()).filter(Boolean)
+    : null;
+
+  const { data, error } = await supabase
+    .from("sessions")
+    .insert({
+      title,
+      time,
+      venue,
+      price,
+      spots_left: spots,
+      roster,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    return { message: error.message };
+  }
+
+  redirect(`/admin/sessions?new=${data.id}`);
+  return { message: null };
+}
+

--- a/src/app/admin/sessions/new/page.tsx
+++ b/src/app/admin/sessions/new/page.tsx
@@ -1,44 +1,17 @@
-import { redirect } from "next/navigation";
-import { getSupabase } from "@/lib/supabaseClient";
+"use client";
+
+import { useFormState } from "react-dom";
+import { createSession, type FormState } from "./actions";
+
+const initialState: FormState = { message: null };
 
 export default function NewSessionPage() {
-  async function createSession(formData: FormData) {
-    "use server";
-    const supabase = getSupabase();
-    const title = formData.get("title") as string;
-    const time = formData.get("time") as string;
-    const venue = formData.get("venue") as string;
-    const price = formData.get("price") as string;
-    const spots = Number(formData.get("spots"));
-    const rosterStr = (formData.get("roster") as string) || "";
-    const roster = rosterStr
-      ? rosterStr.split(",").map((s) => s.trim()).filter(Boolean)
-      : null;
-
-    const { data, error } = await supabase
-      .from("sessions")
-      .insert({
-        title,
-        time,
-        venue,
-        price,
-        spots_left: spots,
-        roster,
-      })
-      .select("id")
-      .single();
-
-    if (error) {
-      throw new Error(error.message);
-    }
-
-    redirect(`/admin/sessions?new=${data.id}`);
-  }
+  const [state, formAction] = useFormState(createSession, initialState);
 
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">
       <h1 className="text-2xl font-semibold mb-4">New Session</h1>
-      <form action={createSession} className="space-y-4">
+      <form action={formAction} className="space-y-4">
         <div>
           <label className="block text-sm font-medium mb-1">Title</label>
           <input name="title" required className="w-full border rounded p-2" />
@@ -63,6 +36,9 @@ export default function NewSessionPage() {
           <label className="block text-sm font-medium mb-1">Roster (comma-separated)</label>
           <input name="roster" className="w-full border rounded p-2" />
         </div>
+        {state.message && (
+          <p className="text-red-600">{state.message}</p>
+        )}
         <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
           Create
         </button>
@@ -70,3 +46,4 @@ export default function NewSessionPage() {
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- move session creation server action to dedicated file and export form state type
- update new session page to use `useFormState` with the server action

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8559186c8320bea5f4511273905d