### PR TITLE
Add payments toggle with price and currency fields

### DIFF
--- a/src/app/admin/sessions/new/actions.ts
+++ b/src/app/admin/sessions/new/actions.ts
@@ -15,23 +15,39 @@ export async function createSession(
   const title = formData.get("title") as string;
   const time = formData.get("time") as string;
   const venue = formData.get("venue") as string;
-  const price = formData.get("price") as string;
+  const paymentsEnabled = formData.get("paymentsEnabled") === "on";
+  const priceStr = formData.get("price") as string | null;
+  const currencyField = (formData.get("currency") as string) || "GBP";
   const spots = Number(formData.get("spots"));
   const rosterStr = (formData.get("roster") as string) || "";
   const roster = rosterStr
     ? rosterStr.split(",").map((s) => s.trim()).filter(Boolean)
     : null;
 
+  let price: number | null = null;
+  let currency: string | null = null;
+  if (paymentsEnabled) {
+    price = priceStr ? parseFloat(priceStr) : NaN;
+    if (!price || price <= 0) {
+      return { message: "Price must be greater than 0" };
+    }
+    currency = currencyField;
+  }
+
+  const sessionForm = {
+    title,
+    time,
+    venue,
+    payments_enabled: paymentsEnabled,
+    price,
+    currency,
+    spots_left: spots,
+    roster,
+  };
+
   const { data, error } = await supabase
     .from("sessions")
-    .insert({
-      title,
-      time,
-      venue,
-      price,
-      spots_left: spots,
-      roster,
-    })
+    .insert(sessionForm)
     .select("id")
     .single();
 

--- a/src/app/admin/sessions/new/page.tsx
+++ b/src/app/admin/sessions/new/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useFormState } from "react-dom";
 import { createSession, type FormState } from "./actions";
 
@@ -7,6 +8,7 @@ const initialState: FormState = { message: null };
 
 export default function NewSessionPage() {
   const [state, formAction] = useFormState(createSession, initialState);
+  const [paymentsEnabled, setPaymentsEnabled] = useState(false);
 
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">
@@ -24,10 +26,43 @@ export default function NewSessionPage() {
           <label className="block text-sm font-medium mb-1">Venue</label>
           <input name="venue" required className="w-full border rounded p-2" />
         </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">Price</label>
-          <input name="price" type="text" required className="w-full border rounded p-2" />
+        <div className="flex items-center">
+          <input
+            id="paymentsEnabled"
+            name="paymentsEnabled"
+            type="checkbox"
+            className="mr-2"
+            checked={paymentsEnabled}
+            onChange={(e) => setPaymentsEnabled(e.target.checked)}
+          />
+          <label htmlFor="paymentsEnabled" className="text-sm font-medium">
+            Collect payments
+          </label>
         </div>
+        {paymentsEnabled && (
+          <>
+            <div>
+              <label className="block text-sm font-medium mb-1">Price</label>
+              <input
+                name="price"
+                type="number"
+                step="0.01"
+                min="0.01"
+                required={paymentsEnabled}
+                className="w-full border rounded p-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Currency</label>
+              <input
+                name="currency"
+                defaultValue="GBP"
+                required={paymentsEnabled}
+                className="w-full border rounded p-2"
+              />
+            </div>
+          </>
+        )}
         <div>
           <label className="block text-sm font-medium mb-1">Spots</label>
           <input name="spots" type="number" required className="w-full border rounded p-2" />

--- a/src/app/admin/sessions/page.tsx
+++ b/src/app/admin/sessions/page.tsx
@@ -14,7 +14,7 @@ export default async function AdminSessions({
   const supabase = getSupabase(); // ⬅️ create client at request time
   const { data: sessions, error } = await supabase
     .from("sessions")
-    .select("id, title, time, venue, price, spots_left, roster");
+    .select("id, title, time, venue, payments_enabled, price, currency, spots_left, roster");
 
   if (error) {
     return <main className="p-6">Error loading sessions: {error.message}</main>;

--- a/src/app/s/[id]/page.tsx
+++ b/src/app/s/[id]/page.tsx
@@ -24,7 +24,11 @@ export default async function SessionPage({ params }: { params: { id: string } }
       <p className="text-sm text-gray-600 mb-4">{session.venue}</p>
 
       <div className="rounded-2xl border p-4 mb-4">
-        <p className="mb-1">Price: <strong>{session.price}</strong></p>
+        {session.payments_enabled ? (
+          <p className="mb-1">
+            Price: <strong>{session.price} {session.currency}</strong>
+          </p>
+        ) : null}
         <p className="mb-2">Spots left: <strong>{session.spots_left}</strong></p>
         <p className="text-sm text-gray-600">
           Confirmed: {session.roster?.map((n: string) => `✅ ${n}`).join(", ")}

--- a/src/lib/shareText.ts
+++ b/src/lib/shareText.ts
@@ -3,7 +3,9 @@ export type SessionRow = {
   title: string;
   time: string | null;
   venue: string | null;
-  price: string | null;
+  payments_enabled: boolean | null;
+  price: number | null;
+  currency: string | null;
   spots_left: number | null;
   roster: string[] | null;
 };
@@ -13,7 +15,11 @@ export function buildShareText(session: SessionRow, url: string): string {
     `${session.title}\n` +
     `Time: ${session.time ?? ""}\n` +
     `Venue: ${session.venue ?? ""}\n` +
-    `Price: ${session.price ?? ""}\n` +
+    `Price: ${
+      session.payments_enabled
+        ? `${session.price ?? ""} ${session.currency ?? ""}`
+        : ""
+    }\n` +
     `Spots left: ${session.spots_left ?? 0}\n` +
     `Join: ${url}`
   );


### PR DESCRIPTION
## Summary
- Add "Collect payments" switch to new session form
- When enabled, display price and currency inputs
- Validate positive price and persist payments info with session data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae2d26b9748320abb1bcca3b61240e