### PR TITLE
Handle session creation redirect client-side

### DIFF
--- a/src/app/admin/sessions/new/actions.ts
+++ b/src/app/admin/sessions/new/actions.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { redirect } from "next/navigation";
 import { getSupabase } from "@/lib/supabaseClient";
 
 export type FormState = {
   message: string | null;
+  sessionId: number | null;
 };
 
 export async function createSession(
@@ -36,10 +36,9 @@ export async function createSession(
     .single();
 
   if (error) {
-    return { message: error.message };
+    return { message: error.message, sessionId: null };
   }
 
-  redirect(`/admin/sessions?new=${data.id}`);
-  return { message: null };
+  return { message: null, sessionId: data.id };
 }
 

--- a/src/app/admin/sessions/new/schedule/page.tsx
+++ b/src/app/admin/sessions/new/schedule/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useFormState } from "react-dom";
+import { useRouter } from "next/navigation";
 import sessionForm, { SessionFormData } from "../sessionForm";
 import { createSession } from "../actions";
 
@@ -20,16 +21,24 @@ export default function SchedulePage() {
     setForm((prev) => ({ ...prev, ...data }));
   }, []);
 
-  function handleSubmit() {
-    sessionForm.clear();
-  }
+  const router = useRouter();
 
-  const [state, formAction] = useFormState(createSession, { message: null });
+  const [state, formAction] = useFormState(createSession, {
+    message: null,
+    sessionId: null,
+  });
+
+  useEffect(() => {
+    if (state.sessionId) {
+      sessionForm.clear();
+      router.push(`/admin/sessions?new=${state.sessionId}`);
+    }
+  }, [state.sessionId, router]);
 
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">
       <h1 className="text-2xl font-semibold mb-4">Schedule</h1>
-      <form action={formAction} onSubmit={handleSubmit} className="space-y-4">
+      <form action={formAction} className="space-y-4">
         <div>
           <p className="text-sm font-medium mb-1">Title</p>
           <p>{form.title}</p>


### PR DESCRIPTION
## Summary
- Return session ID from session creation action instead of redirecting
- Clear session form and redirect on the client after successful session creation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af241616988320b013532de5161dc8