### PR TITLE
refactor: use shared supabase client in checkout

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,26 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import Stripe from "stripe";
-import { createClient } from "@supabase/supabase-js";
 import { headers } from "next/headers";
-
+import { getSupabase } from "@/lib/supabaseClient";
 
 export async function POST(req: NextRequest) {
   try {
     const { sessionId } = await req.json();
 
-    //build-time safe: create clients inside handler. 
+    //build-time safe: create clients inside handler.
     const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
-    const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    );
+    const supabase = getSupabase();
 
     // Dynamic origin to avoid APP_BASE_URL
     const hdrs = await headers();
     const proto = hdrs.get("x-forwarded-proto") ?? "http";
     const host  = hdrs.get("x-forwarded-host") ?? hdrs.get("host") ?? "localhost:3000";
     const origin = `${proto}://${host}`;
-
 
     const { data: s, error } = await supabase
       .from("sessions")
@@ -54,3 +49,4 @@ export async function POST(req: NextRequest) {
 }
 
 }
+


### PR DESCRIPTION
## Summary
- use central `getSupabase` helper in checkout API route
- tidy imports for Next.js types and Supabase client

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon STRIPE_SECRET_KEY=dummy STRIPE_WEBHOOK_SECRET=whsec APP_BASE_URL=http://localhost npm run build` *(fails: failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68af25dc1ee48320ae087d2f5ff286bc