### PR TITLE
chore: add execCommand clipboard fallback

### DIFF
--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -17,16 +17,17 @@ export default function CopyToClipboard({
       await navigator.clipboard.writeText(text);
       setStatus("copied");
     } catch {
+      const ta = document.createElement("textarea");
       try {
-        const ta = document.createElement("textarea");
         ta.value = text;
         document.body.appendChild(ta);
         ta.select();
-        await navigator.clipboard.writeText(ta.value);
-        document.body.removeChild(ta);
+        document.execCommand("copy");
         setStatus("copied");
       } catch {
         setStatus("error");
+      } finally {
+        document.body.removeChild(ta);
       }
     } finally {
       setTimeout(() => setStatus("idle"), 1500);


### PR DESCRIPTION
## Summary
- fall back to `document.execCommand('copy')` when `navigator.clipboard` isn't available
- ensure temporary textarea is removed after copying

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af2bb7f6008320ac46dc6944847a27