### PR TITLE
Use useFormState with createSession for schedule form

### DIFF
--- a/src/app/admin/sessions/new/schedule/page.tsx
+++ b/src/app/admin/sessions/new/schedule/page.tsx
@@ -1,7 +1,69 @@
-export default function SchedulePlaceholder() {
+"use client";
+
+import { useFormState } from "react-dom";
+import { createSession, type FormState } from "../actions";
+
+const initialState: FormState = { message: null };
+
+export default function SchedulePage() {
+  const [state, dispatch] = useFormState(createSession, initialState);
+
   return (
-    <main className="min-h-screen p-6">
-      <p>Schedule step coming soon.</p>
+    <main className="min-h-screen p-6 max-w-md mx-auto">
+      <h1 className="text-2xl font-semibold mb-4">Schedule Session</h1>
+      <form action={dispatch} className="space-y-4">
+        <div>
+          <label htmlFor="title" className="block text-sm font-medium mb-1">
+            Title
+          </label>
+          <input id="title" name="title" className="w-full border rounded p-2" />
+        </div>
+        <div>
+          <label htmlFor="time" className="block text-sm font-medium mb-1">
+            Time
+          </label>
+          <input id="time" name="time" className="w-full border rounded p-2" />
+        </div>
+        <div>
+          <label htmlFor="venue" className="block text-sm font-medium mb-1">
+            Venue
+          </label>
+          <input id="venue" name="venue" className="w-full border rounded p-2" />
+        </div>
+        <div>
+          <label htmlFor="price" className="block text-sm font-medium mb-1">
+            Price
+          </label>
+          <input id="price" name="price" className="w-full border rounded p-2" />
+        </div>
+        <div>
+          <label htmlFor="spots" className="block text-sm font-medium mb-1">
+            Spots
+          </label>
+          <input
+            id="spots"
+            name="spots"
+            type="number"
+            className="w-full border rounded p-2"
+          />
+        </div>
+        <div>
+          <label htmlFor="roster" className="block text-sm font-medium mb-1">
+            Roster (comma-separated)
+          </label>
+          <input id="roster" name="roster" className="w-full border rounded p-2" />
+        </div>
+        {state.message && (
+          <p className="text-red-500 text-sm">{state.message}</p>
+        )}
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Create Session
+        </button>
+      </form>
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- Implement schedule form that uses `useFormState` with the `createSession` server action
- Replace direct `createSession` form action with dispatcher

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c2e75b9c8320973e1e0c2eee638a