### PR TITLE
Clear session draft after successful creation

### DIFF
--- a/src/app/admin/sessions/new/actions.ts
+++ b/src/app/admin/sessions/new/actions.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { redirect } from "next/navigation";
 import { getSupabase } from "@/lib/supabaseClient";
 
 export type FormState = {
   message: string | null;
+  id?: number;
 };
 
 export async function createSession(
@@ -39,7 +39,6 @@ export async function createSession(
     return { message: error.message };
   }
 
-  redirect(`/admin/sessions?new=${data.id}`);
-  return { message: null };
+  return { message: null, id: data.id };
 }
 

--- a/src/app/admin/sessions/new/schedule/page.tsx
+++ b/src/app/admin/sessions/new/schedule/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useFormState } from "react-dom";
+import { useRouter } from "next/navigation";
 import { createSession, type FormState } from "../actions";
 
 const initialState: FormState = { message: null };
@@ -9,6 +10,7 @@ const storageKey = "sessionForm";
 
 export default function SchedulePage() {
   const [state, dispatch] = useFormState(createSession, initialState);
+  const router = useRouter();
   const [title, setTitle] = useState("");
   const [time, setTime] = useState("");
   const [venue, setVenue] = useState("");
@@ -29,6 +31,13 @@ export default function SchedulePage() {
       }
     }
   }, []);
+
+  useEffect(() => {
+    if (!state.message && state.id) {
+      localStorage.removeItem(storageKey);
+      router.replace(`/admin/sessions?new=${state.id}`);
+    }
+  }, [state, router]);
 
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">


### PR DESCRIPTION
## Summary
- Track session creation result and return created session id
- Clear saved session form in browser storage after successful session creation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0cade1e1c83208738adc2005bbd68