### PR TITLE
Unify session scheduling fields

### DIFF
--- a/src/app/admin/sessions/new/actions.ts
+++ b/src/app/admin/sessions/new/actions.ts
@@ -13,8 +13,11 @@ export async function createSession(
 ): Promise<FormState> {
   const supabase = getSupabase();
   const title = formData.get("title") as string;
-  const time = formData.get("time") as string;
+  const date = formData.get("date") as string;
+  const startTime = formData.get("startTime") as string;
+  const endTime = formData.get("endTime") as string;
   const venue = formData.get("venue") as string;
+  const time = endTime ? `${date} ${startTime}-${endTime}` : `${date} ${startTime}`;
   const price = formData.get("price") as string;
   const spots = Number(formData.get("spots"));
   const rosterStr = (formData.get("roster") as string) || "";

--- a/src/app/admin/sessions/new/page.tsx
+++ b/src/app/admin/sessions/new/page.tsx
@@ -11,7 +11,7 @@ import { useRouter } from "next/navigation";
 
 interface FormState {
   title: string;
-  location: string;
+  venue: string;
   date: string;
   startTime: string;
   endTime: string;
@@ -19,7 +19,7 @@ interface FormState {
 
 interface Errors {
   title?: string;
-  location?: string;
+  venue?: string;
   date?: string;
   startTime?: string;
   endTime?: string;
@@ -31,7 +31,7 @@ export default function NewSessionPage() {
   const router = useRouter();
   const [form, setForm] = useState<FormState>({
     title: "",
-    location: "",
+    venue: "",
     date: "",
     startTime: "",
     endTime: "",
@@ -42,7 +42,12 @@ export default function NewSessionPage() {
     const stored = localStorage.getItem(storageKey);
     if (stored) {
       try {
-        setForm(JSON.parse(stored));
+        const data = JSON.parse(stored);
+        if (data.location && !data.venue) {
+          data.venue = data.location;
+          delete data.location;
+        }
+        setForm(data);
       } catch {
         /* ignore */
       }
@@ -52,7 +57,7 @@ export default function NewSessionPage() {
   function validateField(name: string, value: string): string | undefined {
     switch (name) {
       case "title":
-      case "location":
+      case "venue":
       case "date":
       case "startTime":
         if (!value) return "Required";
@@ -118,19 +123,19 @@ export default function NewSessionPage() {
           )}
         </div>
         <div>
-          <label htmlFor="location" className="block text-sm font-medium mb-1">
+          <label htmlFor="venue" className="block text-sm font-medium mb-1">
             Venue
           </label>
           <input
-            id="location"
-            name="location"
-            value={form.location}
+            id="venue"
+            name="venue"
+            value={form.venue}
             onChange={handleChange}
             onBlur={handleBlur}
-            className={`w-full border rounded p-2 ${errors.location ? "border-red-500" : ""}`}
+            className={`w-full border rounded p-2 ${errors.venue ? "border-red-500" : ""}`}
           />
-          {errors.location && (
-            <p className="text-red-500 text-sm mt-1">{errors.location}</p>
+          {errors.venue && (
+            <p className="text-red-500 text-sm mt-1">{errors.venue}</p>
           )}
         </div>
         <div>

--- a/src/app/admin/sessions/new/schedule/page.tsx
+++ b/src/app/admin/sessions/new/schedule/page.tsx
@@ -12,7 +12,9 @@ export default function SchedulePage() {
   const [state, dispatch] = useFormState(createSession, initialState);
   const router = useRouter();
   const [title, setTitle] = useState("");
-  const [time, setTime] = useState("");
+  const [date, setDate] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
   const [venue, setVenue] = useState("");
 
   useEffect(() => {
@@ -21,11 +23,10 @@ export default function SchedulePage() {
       try {
         const data = JSON.parse(stored);
         setTitle(data.title || "");
-        const t = data.date && data.startTime
-          ? `${data.date} ${data.startTime}${data.endTime ? `-${data.endTime}` : ""}`
-          : "";
-        setTime(t);
-        setVenue(data.location || "");
+        setDate(data.date || "");
+        setStartTime(data.startTime || "");
+        setEndTime(data.endTime || "");
+        setVenue(data.venue || data.location || "");
       } catch {
         // ignore malformed storage
       }
@@ -61,11 +62,13 @@ export default function SchedulePage() {
           </label>
           <input
             id="time"
-            name="time"
-            value={time}
+            value={date && startTime ? `${date} ${startTime}${endTime ? `-${endTime}` : ""}` : ""}
             readOnly
             className="w-full border rounded p-2 bg-gray-100"
           />
+          <input type="hidden" name="date" value={date} />
+          <input type="hidden" name="startTime" value={startTime} />
+          <input type="hidden" name="endTime" value={endTime} />
         </div>
         <div>
           <label htmlFor="venue" className="block text-sm font-medium mb-1">


### PR DESCRIPTION
## Summary
- Rename "location" field to "venue" for consistent naming
- Derive session time from date, start, and end fields in the server action
- Prefill review step with stored details and submit hidden schedule metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc189c588320a542b6971c0a3a4f