### PR TITLE
Revise session fields and schema

### DIFF
--- a/src/app/admin/sessions/new/actions.ts
+++ b/src/app/admin/sessions/new/actions.ts
@@ -12,28 +12,21 @@ export async function createSession(
   formData: FormData
 ): Promise<FormState> {
   const supabase = getSupabase();
-  const title = formData.get("title") as string;
   const date = formData.get("date") as string;
   const startTime = formData.get("startTime") as string;
   const endTime = formData.get("endTime") as string;
-  const venue = formData.get("venue") as string;
   const time = endTime ? `${date} ${startTime}-${endTime}` : `${date} ${startTime}`;
-  const price = formData.get("price") as string;
-  const spots = Number(formData.get("spots"));
-  const rosterStr = (formData.get("roster") as string) || "";
-  const roster = rosterStr
-    ? rosterStr.split(",").map((s) => s.trim()).filter(Boolean)
-    : null;
+  const minPlayers = Number(formData.get("minPlayers"));
+  const maxPlayers = Number(formData.get("maxPlayers"));
+  const message = ((formData.get("message") as string) || "").replace(/\n/g, " ").trim() || null;
 
   const { data, error } = await supabase
     .from("sessions")
     .insert({
-      title,
       time,
-      venue,
-      price,
-      spots_left: spots,
-      roster,
+      min_players: isNaN(minPlayers) ? null : minPlayers,
+      max_players: isNaN(maxPlayers) ? null : maxPlayers,
+      message,
     })
     .select("id")
     .single();

--- a/src/app/admin/sessions/new/schedule/page.tsx
+++ b/src/app/admin/sessions/new/schedule/page.tsx
@@ -83,27 +83,36 @@ export default function SchedulePage() {
           />
         </div>
         <div>
-          <label htmlFor="price" className="block text-sm font-medium mb-1">
-            Price
-          </label>
-          <input id="price" name="price" className="w-full border rounded p-2" />
-        </div>
-        <div>
-          <label htmlFor="spots" className="block text-sm font-medium mb-1">
-            Spots
+          <label htmlFor="minPlayers" className="block text-sm font-medium mb-1">
+            Minimum Players
           </label>
           <input
-            id="spots"
-            name="spots"
+            id="minPlayers"
+            name="minPlayers"
             type="number"
             className="w-full border rounded p-2"
           />
         </div>
         <div>
-          <label htmlFor="roster" className="block text-sm font-medium mb-1">
-            Roster (comma-separated)
+          <label htmlFor="maxPlayers" className="block text-sm font-medium mb-1">
+            Maximum Players
           </label>
-          <input id="roster" name="roster" className="w-full border rounded p-2" />
+          <input
+            id="maxPlayers"
+            name="maxPlayers"
+            type="number"
+            className="w-full border rounded p-2"
+          />
+        </div>
+        <div>
+          <label htmlFor="message" className="block text-sm font-medium mb-1">
+            Message
+          </label>
+          <textarea
+            id="message"
+            name="message"
+            className="w-full border rounded p-2"
+          />
         </div>
         {state.message && (
           <p className="text-red-500 text-sm">{state.message}</p>

--- a/src/app/admin/sessions/page.tsx
+++ b/src/app/admin/sessions/page.tsx
@@ -14,7 +14,7 @@ export default async function AdminSessions({
   const supabase = getSupabase(); // ⬅️ create client at request time
   const { data: sessions, error } = await supabase
     .from("sessions")
-    .select("id, title, time, venue, price, spots_left, roster");
+    .select("id, time, min_players, max_players, message");
 
   if (error) {
     return <main className="p-6">Error loading sessions: {error.message}</main>;
@@ -61,19 +61,14 @@ export default async function AdminSessions({
             >
               <Link href={`/s/${s.id}`} className="block">
                 <div className="flex items-baseline justify-between">
-                  <h2 className="text-lg font-medium">{s.title}</h2>
+                  <h2 className="text-lg font-medium">{s.time}</h2>
                   <span className="text-sm text-gray-600">
-                    {s.spots_left ?? 0} left
+                    {s.min_players ?? 0}-{s.max_players ?? 0}
                   </span>
                 </div>
-                <p className="text-sm text-gray-600">
-                  {s.time} • {s.venue}
-                </p>
-                {s.roster?.length ? (
-                  <p className="text-xs text-gray-500 mt-1">
-                    ✅ {s.roster.join(", ")}
-                  </p>
-                ) : null}
+                {s.message && (
+                  <p className="text-sm text-gray-600">{s.message}</p>
+                )}
               </Link>
               <CopyToClipboard text={share} className="mt-2" />
               <a

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: NextRequest) {
 
     const { data: s, error } = await supabase
       .from("sessions")
-      .select("id,title,payg_price_cents")
+      .select("id,payg_price_cents")
       .eq("id", sessionId)
       .single();
 
@@ -37,7 +37,7 @@ export async function POST(req: NextRequest) {
         price_data: {
           currency: "gbp",
           unit_amount: s.payg_price_cents,
-          product_data: { name: s.title }
+          product_data: { name: `Session ${s.id}` }
         },
         quantity: 1
       }],

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,54 +1,24 @@
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
-import { createClient } from "@supabase/supabase-js";
 
-export const dynamic = "force-dynamic";           // 👈 prevent build-time eval
+export const dynamic = "force-dynamic"; // 👈 prevent build-time eval
 export const runtime = "nodejs";
 
-
 export async function POST(req: Request) {
-  //const sig = headers().get("stripe-signature") as string;
-  //const rawBody = await req.text();
-
-  const hdrs = await headers();                            // 👈 await it
-  const sig = hdrs.get("stripe-signature");                // 👈 now .get works
+  const hdrs = await headers();
+  const sig = hdrs.get("stripe-signature");
   if (!sig) {
     return NextResponse.json({ error: "Missing stripe-signature" }, { status: 400 });
   }
   const rawBody = await req.text();
-
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
-  const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
 
-  
-try {
-    const evt = stripe.webhooks.constructEvent(rawBody, sig, process.env.STRIPE_WEBHOOK_SECRET!);
-
-    if (evt.type === "checkout.session.completed") {
-      const s = evt.data.object as Stripe.Checkout.Session;
-      const sessionId = s.metadata?.gamepop_session_id;
-      const payerName = s.customer_details?.name || "Player";
-
-      if (sessionId) {
-        const { data: current } = await supabase
-          .from("sessions").select("spots_left, roster").eq("id", sessionId).single();
-
-        const newSpots = Math.max(0, (current?.spots_left ?? 0) - 1);
-        const newRoster = [...(current?.roster ?? []), payerName];
-
-        await supabase.from("sessions")
-          .update({ spots_left: newSpots, roster: newRoster })
-          .eq("id", sessionId);
-      }
-    }
-
+  try {
+    stripe.webhooks.constructEvent(rawBody, sig, process.env.STRIPE_WEBHOOK_SECRET!);
     return NextResponse.json({ ok: true });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: `Webhook verify failed: ${msg}` }, { status: 400 }); 
+    return NextResponse.json({ error: `Webhook verify failed: ${msg}` }, { status: 400 });
   }
 }

--- a/src/app/s/[id]/page.tsx
+++ b/src/app/s/[id]/page.tsx
@@ -19,17 +19,16 @@ export default async function SessionPage({ params }: { params: { id: string } }
 
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">
-      <h1 className="text-2xl font-semibold mb-1">{session.title}</h1>
+      <h1 className="text-2xl font-semibold mb-1">Session {session.id}</h1>
       <p className="text-sm text-gray-600">{session.time}</p>
-      <p className="text-sm text-gray-600 mb-4">{session.venue}</p>
-
-      <div className="rounded-2xl border p-4 mb-4">
-        <p className="mb-1">Price: <strong>{session.price}</strong></p>
-        <p className="mb-2">Spots left: <strong>{session.spots_left}</strong></p>
-        <p className="text-sm text-gray-600">
-          Confirmed: {session.roster?.map((n: string) => `✅ ${n}`).join(", ")}
-        </p>
-      </div>
+      <p className="text-sm text-gray-600 mb-4">
+        Players: {session.min_players ?? 0}-{session.max_players ?? 0}
+      </p>
+      {session.message && (
+        <div className="rounded-2xl border p-4 mb-4">
+          <p>{session.message}</p>
+        </div>
+      )}
 
       <div className="space-y-2">
         <CheckoutButton sessionId={id} />

--- a/src/lib/shareText.ts
+++ b/src/lib/shareText.ts
@@ -1,20 +1,16 @@
 export type SessionRow = {
   id: string;
-  title: string;
   time: string | null;
-  venue: string | null;
-  price: string | null;
-  spots_left: number | null;
-  roster: string[] | null;
+  min_players: number | null;
+  max_players: number | null;
+  message: string | null;
 };
 
 export function buildShareText(session: SessionRow, url: string): string {
   return (
-    `${session.title}\n` +
-    `Time: ${session.time ?? ""}\n` +
-    `Venue: ${session.venue ?? ""}\n` +
-    `Price: ${session.price ?? ""}\n` +
-    `Spots left: ${session.spots_left ?? 0}\n` +
+    `${session.time ?? ""}\n` +
+    `Players: ${session.min_players ?? ""}-${session.max_players ?? ""}\n` +
+    `${session.message ?? ""}\n` +
     `Join: ${url}`
   );
 }


### PR DESCRIPTION
## Summary
- replace legacy session properties with min/max player counts and sanitized message
- update admin and session pages plus share text and checkout logic to new fields
- simplify Stripe webhook since roster tracking was removed

## Testing
- `npm run lint`
- `npm test` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_68b2248e0a2883208c2cb607ec074b98