### PR TITLE
Add title and venue support to session creation

### DIFF
--- a/src/app/admin/sessions/new/actions.ts
+++ b/src/app/admin/sessions/new/actions.ts
@@ -12,10 +12,12 @@ export async function createSession(
   formData: FormData
 ): Promise<FormState> {
   const supabase = getSupabase();
+  const title = ((formData.get("title") as string) || "").trim();
   const date = formData.get("date") as string;
   const startTime = formData.get("startTime") as string;
   const endTime = formData.get("endTime") as string;
   const time = endTime ? `${date} ${startTime}-${endTime}` : `${date} ${startTime}`;
+  const venue = ((formData.get("venue") as string) || "").trim();
   const minPlayers = Number(formData.get("minPlayers"));
   const maxPlayers = Number(formData.get("maxPlayers"));
   const message = ((formData.get("message") as string) || "").replace(/\n/g, " ").trim() || null;
@@ -23,6 +25,8 @@ export async function createSession(
   const { data, error } = await supabase
     .from("sessions")
     .insert({
+      title: title || null,
+      venue: venue || null,
       time,
       min_players: isNaN(minPlayers) ? null : minPlayers,
       max_players: isNaN(maxPlayers) ? null : maxPlayers,

--- a/src/app/admin/sessions/new/schedule/page.tsx
+++ b/src/app/admin/sessions/new/schedule/page.tsx
@@ -50,11 +50,11 @@ export default function SchedulePage() {
           </label>
           <input
             id="title"
-            name="title"
             value={title}
             readOnly
             className="w-full border rounded p-2 bg-gray-100"
           />
+          <input type="hidden" name="title" value={title} />
         </div>
         <div>
           <label htmlFor="time" className="block text-sm font-medium mb-1">
@@ -76,11 +76,11 @@ export default function SchedulePage() {
           </label>
           <input
             id="venue"
-            name="venue"
             value={venue}
             readOnly
             className="w-full border rounded p-2 bg-gray-100"
           />
+          <input type="hidden" name="venue" value={venue} />
         </div>
         <div>
           <label htmlFor="minPlayers" className="block text-sm font-medium mb-1">

--- a/src/app/admin/sessions/page.tsx
+++ b/src/app/admin/sessions/page.tsx
@@ -14,7 +14,7 @@ export default async function AdminSessions({
   const supabase = getSupabase(); // ⬅️ create client at request time
   const { data: sessions, error } = await supabase
     .from("sessions")
-    .select("id, time, min_players, max_players, message");
+    .select("id, title, venue, time, min_players, max_players, message");
 
   if (error) {
     return <main className="p-6">Error loading sessions: {error.message}</main>;
@@ -61,11 +61,17 @@ export default async function AdminSessions({
             >
               <Link href={`/s/${s.id}`} className="block">
                 <div className="flex items-baseline justify-between">
-                  <h2 className="text-lg font-medium">{s.time}</h2>
+                  <h2 className="text-lg font-medium">
+                    {s.title ?? "Untitled session"}
+                  </h2>
                   <span className="text-sm text-gray-600">
                     {s.min_players ?? 0}-{s.max_players ?? 0}
                   </span>
                 </div>
+                <p className="text-sm text-gray-600">{s.time}</p>
+                {s.venue && (
+                  <p className="text-sm text-gray-600">Venue: {s.venue}</p>
+                )}
                 {s.message && (
                   <p className="text-sm text-gray-600">{s.message}</p>
                 )}

--- a/src/app/s/[id]/page.tsx
+++ b/src/app/s/[id]/page.tsx
@@ -19,8 +19,13 @@ export default async function SessionPage({ params }: { params: { id: string } }
 
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">
-      <h1 className="text-2xl font-semibold mb-1">Session {session.id}</h1>
+      <h1 className="text-2xl font-semibold mb-1">
+        {session.title ?? `Session ${session.id}`}
+      </h1>
       <p className="text-sm text-gray-600">{session.time}</p>
+      {session.venue && (
+        <p className="text-sm text-gray-600">Venue: {session.venue}</p>
+      )}
       <p className="text-sm text-gray-600 mb-4">
         Players: {session.min_players ?? 0}-{session.max_players ?? 0}
       </p>

--- a/src/lib/shareText.ts
+++ b/src/lib/shareText.ts
@@ -1,5 +1,7 @@
 export type SessionRow = {
   id: string;
+  title: string | null;
+  venue: string | null;
   time: string | null;
   min_players: number | null;
   max_players: number | null;


### PR DESCRIPTION
## Summary
- ensure the schedule step submits the saved title and venue values
- persist title and venue when creating sessions and update session typing
- display the stored title and venue on the admin list and session detail pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1658166408320b082381011ee3ac2