### PR TITLE
Include session title and venue in share text

### DIFF
--- a/src/app/admin/sessions/page.tsx
+++ b/src/app/admin/sessions/page.tsx
@@ -14,7 +14,7 @@ export default async function AdminSessions({
   const supabase = getSupabase(); // ⬅️ create client at request time
   const { data: sessions, error } = await supabase
     .from("sessions")
-    .select("id, time, min_players, max_players, message");
+    .select("id, title, venue, time, min_players, max_players, message");
 
   if (error) {
     return <main className="p-6">Error loading sessions: {error.message}</main>;

--- a/src/lib/shareText.ts
+++ b/src/lib/shareText.ts
@@ -1,5 +1,7 @@
 export type SessionRow = {
   id: string;
+  title: string | null;
+  venue: string | null;
   time: string | null;
   min_players: number | null;
   max_players: number | null;
@@ -7,10 +9,31 @@ export type SessionRow = {
 };
 
 export function buildShareText(session: SessionRow, url: string): string {
-  return (
-    `${session.time ?? ""}\n` +
-    `Players: ${session.min_players ?? ""}-${session.max_players ?? ""}\n` +
-    `${session.message ?? ""}\n` +
-    `Join: ${url}`
-  );
+  const lines: string[] = [];
+
+  if (session.title) {
+    lines.push(session.title);
+  }
+
+  if (session.venue) {
+    lines.push(session.venue);
+  }
+
+  if (session.time) {
+    lines.push(session.time);
+  }
+
+  if (session.min_players !== null || session.max_players !== null) {
+    lines.push(
+      `Players: ${session.min_players ?? ""}-${session.max_players ?? ""}`,
+    );
+  }
+
+  if (session.message) {
+    lines.push(session.message);
+  }
+
+  lines.push(`Join: ${url}`);
+
+  return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- prepend the session title and venue when building share text, skipping blank lines for missing fields
- update the admin sessions query to select the new title and venue fields so copy helpers receive them

## Testing
- npm run lint
- node <<'NODE'
const ts = require('typescript');
const fs = require('fs');
const path = require('path');

const filePath = path.join(process.cwd(), 'src/lib/shareText.ts');
const source = fs.readFileSync(filePath, 'utf8');
const transpiled = ts.transpileModule(source, {
  compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2019 },
});

const module = { exports: {} };
const exports = module.exports;
const requireFunc = (id) => require(id);
const wrapped = new Function('require', 'module', 'exports', transpiled.outputText);
wrapped(requireFunc, module, exports);

const { buildShareText } = module.exports;

const share = buildShareText(
  {
    id: '1',
    title: 'Board Game Night',
    venue: 'Community Hall',
    time: '7pm',
    min_players: 3,
    max_players: 6,
    message: 'Bring snacks!',
  },
  'https://example.com',
);

const shareMissing = buildShareText(
  {
    id: '2',
    title: null,
    venue: null,
    time: null,
    min_players: null,
    max_players: null,
    message: null,
  },
  'https://example.com',
);

console.log('Full session:\\n' + share);
console.log('\\nMissing fields:\\n' + shareMissing);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d1690fbd9883209abc8ae61fa64e87