### PR TITLE
Normalize session title and venue handling

### DIFF
--- a/src/app/admin/sessions/new/actions.ts
+++ b/src/app/admin/sessions/new/actions.ts
@@ -12,12 +12,12 @@ export async function createSession(
   formData: FormData
 ): Promise<FormState> {
   const supabase = getSupabase();
-  const title = ((formData.get("title") as string) || "").trim();
+  const title = ((formData.get("title") as string) || "").trim() || null;
   const date = formData.get("date") as string;
   const startTime = formData.get("startTime") as string;
   const endTime = formData.get("endTime") as string;
   const time = endTime ? `${date} ${startTime}-${endTime}` : `${date} ${startTime}`;
-  const venue = ((formData.get("venue") as string) || "").trim();
+  const venue = ((formData.get("venue") as string) || "").trim() || null;
   const minPlayers = Number(formData.get("minPlayers"));
   const maxPlayers = Number(formData.get("maxPlayers"));
   const message = ((formData.get("message") as string) || "").replace(/\n/g, " ").trim() || null;
@@ -25,8 +25,8 @@ export async function createSession(
   const { data, error } = await supabase
     .from("sessions")
     .insert({
-      title: title || null,
-      venue: venue || null,
+      title,
+      venue,
       time,
       min_players: isNaN(minPlayers) ? null : minPlayers,
       max_players: isNaN(maxPlayers) ? null : maxPlayers,


### PR DESCRIPTION
## Summary
- read the session title and venue from the form submission
- normalize blank inputs to null and persist them when inserting sessions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d17207d3a08320b326fe173913b869