### PR TITLE
Adjust shared session text formatting

### DIFF
--- a/src/lib/shareText.ts
+++ b/src/lib/shareText.ts
@@ -9,10 +9,29 @@ export type SessionRow = {
 };
 
 export function buildShareText(session: SessionRow, url: string): string {
-  return (
-    `${session.time ?? ""}\n` +
-    `Players: ${session.min_players ?? ""}-${session.max_players ?? ""}\n` +
-    `${session.message ?? ""}\n` +
-    `Join: ${url}`
+  const lines: string[] = [];
+
+  if (session.title) {
+    lines.push(session.title);
+  }
+
+  if (session.venue) {
+    lines.push(session.venue);
+  }
+
+  if (session.time) {
+    lines.push(session.time);
+  }
+
+  lines.push(
+    `Players: ${session.min_players ?? ""}-${session.max_players ?? ""}`
   );
+
+  if (session.message) {
+    lines.push(session.message);
+  }
+
+  lines.push(`Join: ${url}`);
+
+  return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- prepend the session title and venue to the shared session text so the clipboard matches the on-screen details
- ensure each field in the shared session text appears on its own line for consistent formatting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b80f394c8320b01e064c1fba8c09