### PR TITLE
Add admin session management controls

### DIFF
--- a/src/app/admin/sessions/[id]/edit/page.tsx
+++ b/src/app/admin/sessions/[id]/edit/page.tsx
@@ -1,0 +1,64 @@
+import { notFound } from "next/navigation";
+
+import { getSupabase } from "@/lib/supabaseClient";
+
+import EditSessionForm from "../../components/EditSessionForm";
+import type { SessionFormValues } from "../../components/SessionForm";
+
+export const dynamic = "force-dynamic";
+
+function parseTime(value: string | null): Pick<SessionFormValues, "date" | "startTime" | "endTime"> {
+  if (!value) {
+    return { date: "", startTime: "", endTime: "" };
+  }
+  const [datePart, timePart] = value.split(" ");
+  if (!timePart) {
+    return { date: datePart ?? "", startTime: "", endTime: "" };
+  }
+  const [start, end] = timePart.split("-");
+  return {
+    date: datePart ?? "",
+    startTime: start ?? "",
+    endTime: end ?? "",
+  };
+}
+
+export default async function EditSessionPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const sessionId = Number(params.id);
+  if (!sessionId || Number.isNaN(sessionId)) {
+    notFound();
+  }
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("sessions")
+    .select("id, title, venue, time, min_players, max_players, message")
+    .eq("id", sessionId)
+    .single();
+
+  if (error || !data) {
+    notFound();
+  }
+
+  const timeParts = parseTime(data.time ?? null);
+
+  const initialValues: SessionFormValues = {
+    title: data.title ?? "",
+    venue: data.venue ?? "",
+    message: data.message ?? "",
+    minPlayers: data.min_players != null ? String(data.min_players) : "",
+    maxPlayers: data.max_players != null ? String(data.max_players) : "",
+    ...timeParts,
+  };
+
+  return (
+    <main className="min-h-screen p-6 max-w-md mx-auto">
+      <h1 className="text-2xl font-semibold mb-4">Edit Session</h1>
+      <EditSessionForm sessionId={data.id} initialValues={initialValues} />
+    </main>
+  );
+}

--- a/src/app/admin/sessions/actions.ts
+++ b/src/app/admin/sessions/actions.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getSupabase } from "@/lib/supabaseClient";
+
+import type { FormState } from "./new/actions";
+
+function parseNumberField(value: FormDataEntryValue | null): number | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export async function updateSession(
+  _prevState: FormState,
+  formData: FormData
+): Promise<FormState> {
+  const supabase = getSupabase();
+
+  const idValue = formData.get("id");
+  const id = typeof idValue === "string" ? Number(idValue) : NaN;
+  if (!id || Number.isNaN(id)) {
+    return { message: "Invalid session id" };
+  }
+
+  const title = ((formData.get("title") as string) || "").trim();
+  const date = (formData.get("date") as string) ?? "";
+  const startTime = (formData.get("startTime") as string) ?? "";
+  const endTime = (formData.get("endTime") as string) ?? "";
+  if (!date || !startTime) {
+    return { message: "Date and start time are required" };
+  }
+  const time = endTime ? `${date} ${startTime}-${endTime}` : `${date} ${startTime}`;
+  const venue = ((formData.get("venue") as string) || "").trim();
+  const minPlayers = parseNumberField(formData.get("minPlayers"));
+  const maxPlayers = parseNumberField(formData.get("maxPlayers"));
+  const message =
+    ((formData.get("message") as string) || "").replace(/\n/g, " ").trim() || null;
+
+  const { error } = await supabase
+    .from("sessions")
+    .update({
+      title: title || null,
+      venue: venue || null,
+      time,
+      min_players: minPlayers,
+      max_players: maxPlayers,
+      message,
+    })
+    .eq("id", id);
+
+  if (error) {
+    return { message: error.message };
+  }
+
+  revalidatePath("/admin/sessions");
+  revalidatePath(`/s/${id}`);
+
+  return { message: null, id };
+}
+
+export async function deleteSession(id: number): Promise<{ message: string | null }> {
+  const supabase = getSupabase();
+  const { error } = await supabase.from("sessions").delete().eq("id", id);
+
+  if (error) {
+    return { message: error.message };
+  }
+
+  revalidatePath("/admin/sessions");
+  revalidatePath(`/s/${id}`);
+
+  return { message: null };
+}

--- a/src/app/admin/sessions/components/DeleteSessionButton.tsx
+++ b/src/app/admin/sessions/components/DeleteSessionButton.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { deleteSession } from "../actions";
+
+interface DeleteSessionButtonProps {
+  sessionId: number;
+}
+
+export default function DeleteSessionButton({ sessionId }: DeleteSessionButtonProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = () => {
+    if (!window.confirm("Delete this session?")) {
+      return;
+    }
+    startTransition(async () => {
+      const result = await deleteSession(sessionId);
+      if (result.message) {
+        window.alert(result.message);
+        return;
+      }
+      router.refresh();
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleDelete}
+      title="Delete session"
+      aria-label="Delete session"
+      className="rounded border border-red-200 bg-red-50 px-3 py-1 text-sm text-red-700 transition hover:bg-red-100 disabled:opacity-50"
+      disabled={isPending}
+    >
+      {isPending ? "Deleting…" : "Delete"}
+    </button>
+  );
+}

--- a/src/app/admin/sessions/components/EditSessionForm.tsx
+++ b/src/app/admin/sessions/components/EditSessionForm.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import type { FormState } from "../new/actions";
+import { updateSession } from "../actions";
+import SessionForm, { type SessionFormValues } from "./SessionForm";
+
+interface EditSessionFormProps {
+  sessionId: number;
+  initialValues: SessionFormValues;
+}
+
+export default function EditSessionForm({
+  sessionId,
+  initialValues,
+}: EditSessionFormProps) {
+  const router = useRouter();
+
+  const handleSuccess = useCallback(
+    (state: FormState) => {
+      if (!state.message && state.id) {
+        router.replace(`/admin/sessions?new=${state.id}`);
+        router.refresh();
+      }
+    },
+    [router]
+  );
+
+  return (
+    <SessionForm
+      initial={initialValues}
+      action={updateSession}
+      submitLabel="Save Changes"
+      sessionId={sessionId}
+      onSuccess={handleSuccess}
+    />
+  );
+}

--- a/src/app/admin/sessions/components/SessionForm.tsx
+++ b/src/app/admin/sessions/components/SessionForm.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useFormState } from "react-dom";
+import type { FormState } from "../new/actions";
+
+export type SessionFormValues = {
+  title: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  venue: string;
+  minPlayers: string;
+  maxPlayers: string;
+  message: string;
+};
+
+const INITIAL_FORM_STATE: FormState = { message: null };
+
+function normalizeValues(values?: Partial<SessionFormValues>): SessionFormValues {
+  return {
+    title: values?.title ?? "",
+    date: values?.date ?? "",
+    startTime: values?.startTime ?? "",
+    endTime: values?.endTime ?? "",
+    venue: values?.venue ?? "",
+    minPlayers: values?.minPlayers ?? "",
+    maxPlayers: values?.maxPlayers ?? "",
+    message: values?.message ?? "",
+  };
+}
+
+export interface SessionFormProps {
+  initial?: Partial<SessionFormValues>;
+  action: (state: FormState, formData: FormData) => Promise<FormState>;
+  submitLabel: string;
+  sessionId?: number;
+  onSuccess?: (state: FormState) => void;
+  primaryReadOnly?: boolean;
+}
+
+export default function SessionForm({
+  initial,
+  action,
+  submitLabel,
+  sessionId,
+  onSuccess,
+  primaryReadOnly = false,
+}: SessionFormProps) {
+  const [state, dispatch] = useFormState(action, INITIAL_FORM_STATE);
+  const [values, setValues] = useState<SessionFormValues>(
+    normalizeValues(initial)
+  );
+
+  useEffect(() => {
+    setValues(normalizeValues(initial));
+  }, [initial]);
+
+  useEffect(() => {
+    if (!state.message && onSuccess) {
+      onSuccess(state);
+    }
+  }, [state, onSuccess]);
+
+  const handleChange = useCallback((field: keyof SessionFormValues) => {
+    return (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { value } = event.target;
+      setValues((prev) => ({ ...prev, [field]: value }));
+    };
+  }, []);
+
+  const dateInputType = primaryReadOnly ? "text" : "date";
+  const timeInputType = primaryReadOnly ? "text" : "time";
+
+  return (
+    <form action={dispatch} className="space-y-4">
+      {typeof sessionId === "number" && (
+        <input type="hidden" name="id" value={sessionId} />
+      )}
+      <div>
+        <label htmlFor="title" className="block text-sm font-medium mb-1">
+          Title
+        </label>
+        <input
+          id="title"
+          name="title"
+          value={values.title}
+          onChange={handleChange("title")}
+          readOnly={primaryReadOnly}
+          className={`w-full border rounded p-2 ${primaryReadOnly ? "bg-gray-100" : ""}`}
+        />
+      </div>
+      <div>
+        <label htmlFor="date" className="block text-sm font-medium mb-1">
+          Date
+        </label>
+        <input
+          id="date"
+          name="date"
+          type={dateInputType}
+          value={values.date}
+          onChange={handleChange("date")}
+          readOnly={primaryReadOnly}
+          className={`w-full border rounded p-2 ${primaryReadOnly ? "bg-gray-100" : ""}`}
+        />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="startTime" className="block text-sm font-medium mb-1">
+            Start Time
+          </label>
+          <input
+            id="startTime"
+            name="startTime"
+            type={timeInputType}
+            value={values.startTime}
+            onChange={handleChange("startTime")}
+            readOnly={primaryReadOnly}
+            className={`w-full border rounded p-2 ${primaryReadOnly ? "bg-gray-100" : ""}`}
+          />
+        </div>
+        <div>
+          <label htmlFor="endTime" className="block text-sm font-medium mb-1">
+            End Time (optional)
+          </label>
+          <input
+            id="endTime"
+            name="endTime"
+            type={timeInputType}
+            value={values.endTime}
+            onChange={handleChange("endTime")}
+            readOnly={primaryReadOnly}
+            className={`w-full border rounded p-2 ${primaryReadOnly ? "bg-gray-100" : ""}`}
+          />
+        </div>
+      </div>
+      <div>
+        <label htmlFor="venue" className="block text-sm font-medium mb-1">
+          Venue
+        </label>
+        <input
+          id="venue"
+          name="venue"
+          value={values.venue}
+          onChange={handleChange("venue")}
+          readOnly={primaryReadOnly}
+          className={`w-full border rounded p-2 ${primaryReadOnly ? "bg-gray-100" : ""}`}
+        />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="minPlayers" className="block text-sm font-medium mb-1">
+            Minimum Players
+          </label>
+          <input
+            id="minPlayers"
+            name="minPlayers"
+            type="number"
+            value={values.minPlayers}
+            onChange={handleChange("minPlayers")}
+            className="w-full border rounded p-2"
+          />
+        </div>
+        <div>
+          <label htmlFor="maxPlayers" className="block text-sm font-medium mb-1">
+            Maximum Players
+          </label>
+          <input
+            id="maxPlayers"
+            name="maxPlayers"
+            type="number"
+            value={values.maxPlayers}
+            onChange={handleChange("maxPlayers")}
+            className="w-full border rounded p-2"
+          />
+        </div>
+      </div>
+      <div>
+        <label htmlFor="message" className="block text-sm font-medium mb-1">
+          Message
+        </label>
+        <textarea
+          id="message"
+          name="message"
+          value={values.message}
+          onChange={handleChange("message")}
+          className="w-full border rounded p-2"
+          rows={4}
+        />
+      </div>
+      {state.message && (
+        <p className="text-red-500 text-sm">{state.message}</p>
+      )}
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+        {submitLabel}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/sessions/new/actions.ts
+++ b/src/app/admin/sessions/new/actions.ts
@@ -18,8 +18,15 @@ export async function createSession(
   const endTime = formData.get("endTime") as string;
   const time = endTime ? `${date} ${startTime}-${endTime}` : `${date} ${startTime}`;
   const venue = ((formData.get("venue") as string) || "").trim();
-  const minPlayers = Number(formData.get("minPlayers"));
-  const maxPlayers = Number(formData.get("maxPlayers"));
+  const parseNumberField = (value: FormDataEntryValue | null): number | null => {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isNaN(parsed) ? null : parsed;
+  };
+  const minPlayers = parseNumberField(formData.get("minPlayers"));
+  const maxPlayers = parseNumberField(formData.get("maxPlayers"));
   const message = ((formData.get("message") as string) || "").replace(/\n/g, " ").trim() || null;
 
   const { data, error } = await supabase
@@ -28,8 +35,8 @@ export async function createSession(
       title: title || null,
       venue: venue || null,
       time,
-      min_players: isNaN(minPlayers) ? null : minPlayers,
-      max_players: isNaN(maxPlayers) ? null : maxPlayers,
+      min_players: minPlayers,
+      max_players: maxPlayers,
       message,
     })
     .select("id")

--- a/src/app/admin/sessions/new/schedule/page.tsx
+++ b/src/app/admin/sessions/new/schedule/page.tsx
@@ -1,130 +1,69 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useFormState } from "react-dom";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+
+import SessionForm, {
+  type SessionFormValues,
+} from "../../components/SessionForm";
 import { createSession, type FormState } from "../actions";
 
-const initialState: FormState = { message: null };
 const storageKey = "sessionForm";
 
 export default function SchedulePage() {
-  const [state, dispatch] = useFormState(createSession, initialState);
   const router = useRouter();
-  const [title, setTitle] = useState("");
-  const [date, setDate] = useState("");
-  const [startTime, setStartTime] = useState("");
-  const [endTime, setEndTime] = useState("");
-  const [venue, setVenue] = useState("");
+  const [initialValues, setInitialValues] = useState<SessionFormValues>({
+    title: "",
+    date: "",
+    startTime: "",
+    endTime: "",
+    venue: "",
+    minPlayers: "",
+    maxPlayers: "",
+    message: "",
+  });
 
   useEffect(() => {
     const stored = typeof window !== "undefined" && localStorage.getItem(storageKey);
     if (stored) {
       try {
         const data = JSON.parse(stored);
-        setTitle(data.title || "");
-        setDate(data.date || "");
-        setStartTime(data.startTime || "");
-        setEndTime(data.endTime || "");
-        setVenue(data.venue || data.location || "");
+        setInitialValues((prev) => ({
+          ...prev,
+          title: data.title || "",
+          date: data.date || "",
+          startTime: data.startTime || "",
+          endTime: data.endTime || "",
+          venue: data.venue || data.location || "",
+        }));
       } catch {
         // ignore malformed storage
       }
     }
   }, []);
 
-  useEffect(() => {
-    if (!state.message && state.id) {
-      localStorage.removeItem(storageKey);
-      router.replace(`/admin/sessions?new=${state.id}`);
-    }
-  }, [state, router]);
+  const handleSuccess = useCallback(
+    (state: FormState) => {
+      if (!state.message && state.id) {
+        if (typeof window !== "undefined") {
+          localStorage.removeItem(storageKey);
+        }
+        router.replace(`/admin/sessions?new=${state.id}`);
+      }
+    },
+    [router]
+  );
 
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">
       <h1 className="text-2xl font-semibold mb-4">Schedule Session</h1>
-      <form action={dispatch} className="space-y-4">
-        <div>
-          <label htmlFor="title" className="block text-sm font-medium mb-1">
-            Title
-          </label>
-          <input
-            id="title"
-            value={title}
-            readOnly
-            className="w-full border rounded p-2 bg-gray-100"
-          />
-          <input type="hidden" name="title" value={title} />
-        </div>
-        <div>
-          <label htmlFor="time" className="block text-sm font-medium mb-1">
-            Time
-          </label>
-          <input
-            id="time"
-            value={date && startTime ? `${date} ${startTime}${endTime ? `-${endTime}` : ""}` : ""}
-            readOnly
-            className="w-full border rounded p-2 bg-gray-100"
-          />
-          <input type="hidden" name="date" value={date} />
-          <input type="hidden" name="startTime" value={startTime} />
-          <input type="hidden" name="endTime" value={endTime} />
-        </div>
-        <div>
-          <label htmlFor="venue" className="block text-sm font-medium mb-1">
-            Venue
-          </label>
-          <input
-            id="venue"
-            value={venue}
-            readOnly
-            className="w-full border rounded p-2 bg-gray-100"
-          />
-          <input type="hidden" name="venue" value={venue} />
-        </div>
-        <div>
-          <label htmlFor="minPlayers" className="block text-sm font-medium mb-1">
-            Minimum Players
-          </label>
-          <input
-            id="minPlayers"
-            name="minPlayers"
-            type="number"
-            className="w-full border rounded p-2"
-          />
-        </div>
-        <div>
-          <label htmlFor="maxPlayers" className="block text-sm font-medium mb-1">
-            Maximum Players
-          </label>
-          <input
-            id="maxPlayers"
-            name="maxPlayers"
-            type="number"
-            className="w-full border rounded p-2"
-          />
-        </div>
-        <div>
-          <label htmlFor="message" className="block text-sm font-medium mb-1">
-            Message
-          </label>
-          <textarea
-            id="message"
-            name="message"
-            className="w-full border rounded p-2"
-          />
-        </div>
-        {state.message && (
-          <p className="text-red-500 text-sm">{state.message}</p>
-        )}
-        <button
-          type="submit"
-          className="px-4 py-2 bg-blue-600 text-white rounded"
-        >
-          Create Session
-        </button>
-      </form>
+      <SessionForm
+        initial={initialValues}
+        action={createSession}
+        submitLabel="Create Session"
+        primaryReadOnly
+        onSuccess={handleSuccess}
+      />
     </main>
   );
 }
-

--- a/src/app/admin/sessions/page.tsx
+++ b/src/app/admin/sessions/page.tsx
@@ -1,8 +1,11 @@
 import Link from "next/link";
 import { headers } from "next/headers";
-import { getSupabase } from "@/lib/supabaseClient";
+
 import CopyToClipboard from "@/components/CopyToClipboard";
+import { getSupabase } from "@/lib/supabaseClient";
 import { buildShareText, type SessionRow } from "@/lib/shareText";
+
+import DeleteSessionButton from "./components/DeleteSessionButton";
 
 export const dynamic = "force-dynamic";  // ⬅️ stop static prerender at build
 
@@ -98,31 +101,64 @@ export default async function AdminSessions({
                 key={s.id}
                 className={`rounded-2xl border p-4 ${highlight ? "border-blue-500 bg-blue-50" : ""}`}
               >
-                <Link href={`/s/${s.id}`} className="block">
-                  <div className="flex items-baseline justify-between">
-                    <h2 className="text-lg font-medium">
-                      {s.title ?? "Untitled session"}
-                    </h2>
-                    <span className="text-sm text-gray-600">
-                      {s.min_players ?? 0}-{s.max_players ?? 0}
-                    </span>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <Link
+                    href={`/s/${s.id}`}
+                    className="flex-1 space-y-1"
+                    aria-label={`View session ${s.title ?? "Untitled session"}`}
+                  >
+                    <div className="flex items-baseline justify-between gap-3">
+                      <h2 className="text-lg font-medium">
+                        {s.title ?? "Untitled session"}
+                      </h2>
+                      <span className="text-sm text-gray-600">
+                        {s.min_players ?? 0}-{s.max_players ?? 0}
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-600">{s.time}</p>
+                    {s.venue && (
+                      <p className="text-sm text-gray-600">Venue: {s.venue}</p>
+                    )}
+                    {s.message && (
+                      <p className="text-sm text-gray-600">{s.message}</p>
+                    )}
+                  </Link>
+                  <div className="flex flex-row flex-wrap gap-2 sm:w-40 sm:flex-col">
+                    <Link
+                      href={`/s/${s.id}`}
+                      className="rounded border border-gray-300 px-3 py-1 text-sm text-blue-600 transition hover:bg-blue-50"
+                      title="View session"
+                      aria-label="View session"
+                    >
+                      View
+                    </Link>
+                    <Link
+                      href={`/admin/sessions/${s.id}/edit`}
+                      className="rounded border border-gray-300 px-3 py-1 text-sm text-blue-600 transition hover:bg-blue-50"
+                      title="Edit session"
+                      aria-label="Edit session"
+                    >
+                      Edit
+                    </Link>
+                    <DeleteSessionButton sessionId={s.id} />
                   </div>
-                  <p className="text-sm text-gray-600">{s.time}</p>
-                  {s.venue && (
-                    <p className="text-sm text-gray-600">Venue: {s.venue}</p>
-                  )}
-                  {s.message && (
-                    <p className="text-sm text-gray-600">{s.message}</p>
-                  )}
-                </Link>
-                <CopyToClipboard text={share} className="mt-2" />
-                <a
-                  href={"https://wa.me/?text=" + encodeURIComponent(share)}
-                  target="_blank"
-                  className="block mt-1 text-sm text-blue-600 underline"
-                >
-                  Open in WhatsApp
-                </a>
+                </div>
+                <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                  <CopyToClipboard
+                    text={share}
+                    className="w-full justify-center sm:w-auto"
+                  />
+                  <a
+                    href={"https://wa.me/?text=" + encodeURIComponent(share)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-blue-600 underline"
+                    title="Share via WhatsApp"
+                    aria-label="Share via WhatsApp"
+                  >
+                    Open in WhatsApp
+                  </a>
+                </div>
               </li>
             );
           })}


### PR DESCRIPTION
## Summary
- restructure admin session cards to include inline view, edit, and delete controls while preserving share utilities
- add reusable session form plus Supabase update and delete server actions
- implement an admin edit page that loads existing session data and saves changes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2c927a1fc8320b8a866d37831625d