### PR TITLE
Add admin session edit route and form

### DIFF
--- a/src/app/admin/sessions/[id]/edit/page.tsx
+++ b/src/app/admin/sessions/[id]/edit/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getSupabase } from "@/lib/supabaseClient";
+import { EditSessionForm } from "../../components/SessionForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditSessionPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { id } = params;
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from("sessions")
+    .select("id, title, time, venue, min_players, max_players, message")
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116" || error.code === "PGRST103") {
+      notFound();
+    }
+    throw new Error(error.message);
+  }
+
+  if (!data) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen p-6 max-w-md mx-auto space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">Edit session</h1>
+        <p className="text-sm text-gray-600">
+          Update the session details below. Time is stored as free text, so keep
+          the same format when editing.
+        </p>
+        <Link href="/admin/sessions" className="text-blue-600 underline text-sm">
+          Back to sessions
+        </Link>
+      </div>
+      <EditSessionForm sessionId={data.id} defaultValues={data} />
+    </main>
+  );
+}

--- a/src/app/admin/sessions/actions.ts
+++ b/src/app/admin/sessions/actions.ts
@@ -1,0 +1,82 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { getSupabase } from "@/lib/supabaseClient";
+
+export type UpdateSessionState = {
+  message: string | null;
+  success: boolean;
+};
+
+const successState: UpdateSessionState = { message: null, success: true };
+const errorState = (message: string): UpdateSessionState => ({
+  message,
+  success: false,
+});
+
+export async function updateSession(
+  _prevState: UpdateSessionState,
+  formData: FormData
+): Promise<UpdateSessionState> {
+  const supabase = getSupabase();
+  const id = ((formData.get("id") as string) || "").trim();
+  if (!id) {
+    return errorState("Missing session id");
+  }
+
+  const title = ((formData.get("title") as string) || "").trim();
+  const time = ((formData.get("time") as string) || "").trim() || null;
+  const venue = ((formData.get("venue") as string) || "").trim() || null;
+  const parseNumber = (value: FormDataEntryValue | null) => {
+    if (value === null) return null;
+    const asString = String(value).trim();
+    if (!asString) return null;
+    return Number(asString);
+  };
+
+  const minPlayers = parseNumber(formData.get("minPlayers"));
+  const maxPlayers = parseNumber(formData.get("maxPlayers"));
+  const message = ((formData.get("message") as string) || "").trim() || null;
+
+  if (Number.isNaN(minPlayers) || Number.isNaN(maxPlayers)) {
+    return errorState("Player counts must be numbers");
+  }
+
+  const { error } = await supabase
+    .from("sessions")
+    .update({
+      title: title || null,
+      time,
+      venue,
+      min_players: minPlayers,
+      max_players: maxPlayers,
+      message,
+    })
+    .eq("id", id);
+
+  if (error) {
+    return errorState(error.message);
+  }
+
+  revalidatePath("/admin/sessions");
+  revalidatePath(`/admin/sessions/${id}/edit`);
+
+  return successState;
+}
+
+export async function deleteSession(formData: FormData): Promise<void> {
+  const supabase = getSupabase();
+  const id = ((formData.get("id") as string) || "").trim();
+  if (!id) {
+    throw new Error("Missing session id");
+  }
+
+  const { error } = await supabase.from("sessions").delete().eq("id", id);
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidatePath("/admin/sessions");
+  redirect("/admin/sessions");
+}

--- a/src/app/admin/sessions/components/SessionForm.tsx
+++ b/src/app/admin/sessions/components/SessionForm.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import {
+  deleteSession,
+  updateSession,
+  type UpdateSessionState,
+} from "../actions";
+
+export type SessionFormProps = {
+  sessionId?: string;
+  defaultValues: {
+    title: string | null;
+    time: string | null;
+    venue: string | null;
+    min_players: number | null;
+    max_players: number | null;
+    message: string | null;
+  };
+};
+
+const initialState: UpdateSessionState = { message: null, success: false };
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-70"
+      disabled={pending}
+    >
+      {pending ? "Saving..." : label}
+    </button>
+  );
+}
+
+function DeleteButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="px-4 py-2 bg-red-600 text-white rounded disabled:opacity-70"
+      disabled={pending}
+    >
+      {pending ? "Deleting..." : "Delete session"}
+    </button>
+  );
+}
+
+export function EditSessionForm({ sessionId, defaultValues }: SessionFormProps) {
+  const [state, formAction] = useFormState(updateSession, initialState);
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  useEffect(() => {
+    if (state.success) {
+      setShowSuccess(true);
+      const timer = setTimeout(() => setShowSuccess(false), 3000);
+      return () => clearTimeout(timer);
+    }
+    setShowSuccess(false);
+    return undefined;
+  }, [state.success]);
+
+  return (
+    <div className="space-y-6">
+      <form action={formAction} className="space-y-4">
+        {sessionId ? <input type="hidden" name="id" value={sessionId} /> : null}
+        <div>
+          <label htmlFor="title" className="block text-sm font-medium mb-1">
+            Title
+          </label>
+          <input
+            id="title"
+            name="title"
+            defaultValue={defaultValues.title ?? ""}
+            className="w-full border rounded p-2"
+          />
+        </div>
+        <div>
+          <label htmlFor="time" className="block text-sm font-medium mb-1">
+            Time
+          </label>
+          <input
+            id="time"
+            name="time"
+            defaultValue={defaultValues.time ?? ""}
+            className="w-full border rounded p-2"
+            placeholder="2024-05-01 18:00-20:00"
+          />
+        </div>
+        <div>
+          <label htmlFor="venue" className="block text-sm font-medium mb-1">
+            Venue
+          </label>
+          <input
+            id="venue"
+            name="venue"
+            defaultValue={defaultValues.venue ?? ""}
+            className="w-full border rounded p-2"
+          />
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="minPlayers" className="block text-sm font-medium mb-1">
+              Minimum players
+            </label>
+            <input
+              id="minPlayers"
+              name="minPlayers"
+              type="number"
+              defaultValue={
+                defaultValues.min_players === null
+                  ? ""
+                  : defaultValues.min_players
+              }
+              className="w-full border rounded p-2"
+            />
+          </div>
+          <div>
+            <label htmlFor="maxPlayers" className="block text-sm font-medium mb-1">
+              Maximum players
+            </label>
+            <input
+              id="maxPlayers"
+              name="maxPlayers"
+              type="number"
+              defaultValue={
+                defaultValues.max_players === null
+                  ? ""
+                  : defaultValues.max_players
+              }
+              className="w-full border rounded p-2"
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="message" className="block text-sm font-medium mb-1">
+            Message
+          </label>
+          <textarea
+            id="message"
+            name="message"
+            defaultValue={defaultValues.message ?? ""}
+            className="w-full border rounded p-2"
+            rows={4}
+          />
+        </div>
+        {state.message ? (
+          <p className="text-sm text-red-600">{state.message}</p>
+        ) : null}
+        {showSuccess ? (
+          <p className="text-sm text-green-600">Changes saved</p>
+        ) : null}
+        <SubmitButton label="Save changes" />
+      </form>
+      {sessionId ? (
+        <form
+          action={deleteSession}
+          onSubmit={(event) => {
+            if (!window.confirm("Delete this session?")) {
+              event.preventDefault();
+            }
+          }}
+          className="border-t pt-4"
+        >
+          <input type="hidden" name="id" value={sessionId} />
+          <DeleteButton />
+        </form>
+      ) : null}
+    </div>
+  );
+}
+
+export default EditSessionForm;

--- a/src/app/admin/sessions/page.tsx
+++ b/src/app/admin/sessions/page.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { getSupabase } from "@/lib/supabaseClient";
 import CopyToClipboard from "@/components/CopyToClipboard";
 import { buildShareText, type SessionRow } from "@/lib/shareText";
+import { deleteSession } from "./actions";
 
 export const dynamic = "force-dynamic";  // ⬅️ stop static prerender at build
 
@@ -123,6 +124,23 @@ export default async function AdminSessions({
                 >
                   Open in WhatsApp
                 </a>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Link
+                    href={`/admin/sessions/${s.id}/edit`}
+                    className="rounded border border-blue-600 px-3 py-2 text-sm font-medium text-blue-600"
+                  >
+                    Edit
+                  </Link>
+                  <form action={deleteSession}>
+                    <input type="hidden" name="id" value={s.id} />
+                    <button
+                      type="submit"
+                      className="rounded border border-red-600 px-3 py-2 text-sm font-medium text-red-600"
+                    >
+                      Delete
+                    </button>
+                  </form>
+                </div>
               </li>
             );
           })}

--- a/src/app/s/[id]/page.tsx
+++ b/src/app/s/[id]/page.tsx
@@ -1,5 +1,7 @@
+import Link from "next/link";
 import CheckoutButton from "@/components/CheckoutButton";
 import { getSupabase } from "@/lib/supabaseClient";
+import { deleteSession } from "@/app/admin/sessions/actions";
 
 export const dynamic = "force-dynamic";  // ⬅️ stop static prerender
 
@@ -39,6 +41,27 @@ export default async function SessionPage({ params }: { params: { id: string } }
         <CheckoutButton sessionId={id} />
         <button className="w-full rounded-xl border py-3">Join Waitlist</button>
         <button className="w-full text-gray-500 text-sm">View Policy</button>
+      </div>
+
+      <div className="mt-6 space-y-3 border-t pt-4">
+        <p className="text-sm font-medium text-gray-700">Admin actions</p>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href={`/admin/sessions/${id}/edit`}
+            className="rounded border border-blue-600 px-3 py-2 text-sm font-medium text-blue-600"
+          >
+            Edit session
+          </Link>
+          <form action={deleteSession}>
+            <input type="hidden" name="id" value={id} />
+            <button
+              type="submit"
+              className="rounded border border-red-600 px-3 py-2 text-sm font-medium text-red-600"
+            >
+              Delete session
+            </button>
+          </form>
+        </div>
       </div>
 
       <p className="mt-6 text-xs text-gray-400">Session ID: <code>{id}</code></p>


### PR DESCRIPTION
## Summary
- add server actions to update and delete admin sessions
- build a reusable session form component that drives updates from the browser
- add the /admin/sessions/[id]/edit route that fetches a session and renders the form

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5692b8e7883209a524e2228dfc2eb