### PR TITLE
Add session responses migration and types

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,15 @@
+export type ContactType = "email" | "phone_whatsapp" | (string & {});
+
+export type ResponseStatus = "in" | "out" | "maybe" | (string & {});
+
+export type SessionResponse = {
+  id: string;
+  session_id: string;
+  player_name: string;
+  player_name_search: string;
+  email: string | null;
+  phone_whatsapp: string | null;
+  preferred_contact: ContactType | null;
+  status: ResponseStatus | null;
+  updated_at: string;
+};

--- a/supabase/migrations/20250110120000_create_session_responses.sql
+++ b/supabase/migrations/20250110120000_create_session_responses.sql
@@ -1,0 +1,16 @@
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.session_responses (
+  id uuid primary key default uuid_generate_v4(),
+  session_id uuid not null references public.sessions(id) on delete cascade,
+  player_name text not null,
+  player_name_search text generated always as (lower(player_name)) stored,
+  email text,
+  phone_whatsapp text,
+  preferred_contact contact_type,
+  status response_status,
+  updated_at timestamptz default now()
+);
+
+create unique index if not exists session_responses_session_contact_key
+  on public.session_responses (session_id, coalesce(email, phone_whatsapp, player_name_search));


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates the session_responses table with generated search column and cascade constraints
- add a unique index that allows responders to update their own entries by contact info
- introduce shared TypeScript types for session responses and related enums

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c39807a88320b179f3f773f6c40c