### PR TITLE
Add RSVP controls with API route for session responses

### DIFF
--- a/src/app/api/sessions/[id]/rsvp/route.ts
+++ b/src/app/api/sessions/[id]/rsvp/route.ts
@@ -1,0 +1,196 @@
+import { NextResponse } from "next/server";
+
+import { getSupabase } from "@/lib/supabaseClient";
+
+const ALLOWED_STATUSES = new Set(["in", "out", "maybe"]);
+const ALLOWED_CONTACT = new Set(["email", "phone"]);
+
+type RSVPRequestBody = {
+  playerName?: unknown;
+  email?: unknown;
+  phone?: unknown;
+  preferredContact?: unknown;
+  status?: unknown;
+};
+
+type ResponseStatus = "in" | "out" | "maybe";
+type ContactPreference = "email" | "phone" | null;
+
+type SessionResponseRow = {
+  id: string;
+  session_id: string;
+  player_name: string;
+  player_name_search: string | null;
+  email: string | null;
+  phone_whatsapp: string | null;
+  preferred_contact: ContactPreference;
+  status: ResponseStatus | null;
+  updated_at: string | null;
+};
+
+function buildContactKey({
+  email,
+  phone,
+  playerName,
+}: {
+  email: string | null;
+  phone: string | null;
+  playerName: string;
+}) {
+  if (email) {
+    return email.toLowerCase();
+  }
+  if (phone) {
+    return phone.toLowerCase();
+  }
+  return playerName.trim().toLowerCase();
+}
+
+async function findExistingResponse(
+  sessionId: string,
+  {
+    email,
+    phone,
+    playerName,
+  }: { email: string | null; phone: string | null; playerName: string },
+): Promise<SessionResponseRow | null> {
+  const supabase = getSupabase();
+
+  if (email) {
+    const { data } = await supabase
+      .from("session_responses")
+      .select("*")
+      .eq("session_id", sessionId)
+      .ilike("email", email)
+      .maybeSingle<SessionResponseRow>();
+    if (data) {
+      return data;
+    }
+  }
+
+  if (phone) {
+    const { data } = await supabase
+      .from("session_responses")
+      .select("*")
+      .eq("session_id", sessionId)
+      .ilike("phone_whatsapp", phone)
+      .maybeSingle<SessionResponseRow>();
+    if (data) {
+      return data;
+    }
+  }
+
+  const loweredName = playerName.trim().toLowerCase();
+  if (!loweredName) {
+    return null;
+  }
+
+  const { data } = await supabase
+    .from("session_responses")
+    .select("*")
+    .eq("session_id", sessionId)
+    .eq("player_name_search", loweredName)
+    .maybeSingle<SessionResponseRow>();
+
+  return data ?? null;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const { id: sessionId } = params;
+  let body: RSVPRequestBody;
+
+  try {
+    body = (await request.json()) as RSVPRequestBody;
+  } catch {
+    return NextResponse.json({ message: "Invalid request payload." }, { status: 400 });
+  }
+
+  const playerName = typeof body.playerName === "string" ? body.playerName.trim() : "";
+  const emailRaw = typeof body.email === "string" ? body.email.trim() : "";
+  const phoneRaw = typeof body.phone === "string" ? body.phone.trim() : "";
+  const status = typeof body.status === "string" ? body.status.toLowerCase() : "";
+  const preferredContactValue =
+    typeof body.preferredContact === "string" ? body.preferredContact.toLowerCase() : null;
+
+  if (!playerName) {
+    return NextResponse.json({ message: "Name is required." }, { status: 400 });
+  }
+
+  if (!ALLOWED_STATUSES.has(status)) {
+    return NextResponse.json({ message: "Invalid RSVP status." }, { status: 400 });
+  }
+
+  let preferredContact: ContactPreference = null;
+  if (preferredContactValue && ALLOWED_CONTACT.has(preferredContactValue)) {
+    preferredContact = preferredContactValue as ContactPreference;
+  }
+
+  const email = emailRaw ? emailRaw : null;
+  const phone = phoneRaw ? phoneRaw : null;
+
+  const supabase = getSupabase();
+  const existingResponse = await findExistingResponse(sessionId, {
+    email,
+    phone,
+    playerName,
+  });
+
+  const payload = {
+    session_id: sessionId,
+    player_name: playerName,
+    email,
+    phone_whatsapp: phone,
+    preferred_contact: preferredContact,
+    status: status as ResponseStatus,
+  } satisfies Partial<SessionResponseRow> & { session_id: string; player_name: string };
+
+  let savedResponse: SessionResponseRow | null = null;
+
+  if (existingResponse) {
+    const { data, error } = await supabase
+      .from("session_responses")
+      .update(payload)
+      .eq("id", existingResponse.id)
+      .select()
+      .maybeSingle<SessionResponseRow>();
+
+    if (error) {
+      return NextResponse.json({ message: "Unable to update RSVP." }, { status: 500 });
+    }
+
+    savedResponse = data ?? existingResponse;
+  } else {
+    const { data, error } = await supabase
+      .from("session_responses")
+      .insert(payload)
+      .select()
+      .maybeSingle<SessionResponseRow>();
+
+    if (error) {
+      return NextResponse.json({ message: "Unable to save RSVP." }, { status: 500 });
+    }
+
+    savedResponse = data ?? null;
+  }
+
+  const contactKey = buildContactKey({
+    email,
+    phone,
+    playerName,
+  });
+
+  const response = NextResponse.json({ success: true, response: savedResponse });
+  response.cookies.set({
+    name: `session-rsvp-${sessionId}`,
+    value: contactKey,
+    httpOnly: false,
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 180, // ~6 months
+    path: "/",
+  });
+
+  return response;
+}

--- a/src/app/s/[id]/page.tsx
+++ b/src/app/s/[id]/page.tsx
@@ -1,33 +1,77 @@
+import { cookies } from "next/headers";
 import Link from "next/link";
-import CheckoutButton from "@/components/CheckoutButton";
-import { getSupabase } from "@/lib/supabaseClient";
+
+import RSVPControls from "@/components/RSVPControls";
 import { deleteSession } from "@/app/admin/sessions/actions";
+import { getSupabase } from "@/lib/supabaseClient";
 
-export const dynamic = "force-dynamic";  // ⬅️ stop static prerender
+export const dynamic = "force-dynamic"; // ⬅️ stop static prerender
 
-export default async function SessionPage({ params }: { params: { id: string } }) {
-  const { id } = params;
-  const supabase = getSupabase();        // ⬅️ create client inside
+type SessionResponse = {
+  id: string;
+  player_name: string;
+  player_name_search?: string | null;
+  email: string | null;
+  phone_whatsapp: string | null;
+  preferred_contact: "email" | "phone" | null;
+  status: "in" | "out" | "maybe" | null;
+  updated_at: string | null;
+};
+
+type SessionRecord = {
+  id: string;
+  title: string | null;
+  time: string | null;
+  venue: string | null;
+  min_players: number | null;
+  max_players: number | null;
+  message: string | null;
+  require_contact?: boolean | null;
+  session_responses?: SessionResponse[] | null;
+};
+
+export default async function SessionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = getSupabase();
 
   const { data: session, error } = await supabase
     .from("sessions")
-    .select("*")
+    .select(
+      `id, title, time, venue, min_players, max_players, message, require_contact, session_responses(id, player_name, player_name_search, email, phone_whatsapp, preferred_contact, status, updated_at)`,
+    )
     .eq("id", id)
-    .single();
+    .single<SessionRecord>();
 
   if (error || !session) {
     return <p className="p-6">Session not found</p>;
   }
 
+  const sessionResponses = session.session_responses ?? [];
+  const cookieStore = cookies();
+  const responseCookieKey = `session-rsvp-${id}`;
+  const savedContactKey = cookieStore.get(responseCookieKey)?.value;
+
+  const initialResponse = savedContactKey
+    ? sessionResponses.find((response) => {
+        const contactKey =
+          response.email?.toLowerCase() ??
+          response.phone_whatsapp?.toLowerCase() ??
+          response.player_name_search ??
+          response.player_name?.toLowerCase() ??
+          null;
+        return contactKey === savedContactKey;
+      }) ?? null
+    : null;
+
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">
-      <h1 className="text-2xl font-semibold mb-1">
-        {session.title ?? `Session ${session.id}`}
-      </h1>
+      <h1 className="text-2xl font-semibold mb-1">{session.title ?? `Session ${session.id}`}</h1>
       <p className="text-sm text-gray-600">{session.time}</p>
-      {session.venue && (
-        <p className="text-sm text-gray-600">Venue: {session.venue}</p>
-      )}
+      {session.venue && <p className="text-sm text-gray-600">Venue: {session.venue}</p>}
       <p className="text-sm text-gray-600 mb-4">
         Players: {session.min_players ?? 0}-{session.max_players ?? 0}
       </p>
@@ -37,11 +81,21 @@ export default async function SessionPage({ params }: { params: { id: string } }
         </div>
       )}
 
-      <div className="space-y-2">
-        <CheckoutButton sessionId={id} />
-        <button className="w-full rounded-xl border py-3">Join Waitlist</button>
-        <button className="w-full text-gray-500 text-sm">View Policy</button>
-      </div>
+      <RSVPControls
+        sessionId={id}
+        initialResponse={
+          initialResponse
+            ? {
+                player_name: initialResponse.player_name,
+                email: initialResponse.email,
+                phone_whatsapp: initialResponse.phone_whatsapp,
+                preferred_contact: initialResponse.preferred_contact,
+                status: initialResponse.status,
+              }
+            : null
+        }
+        requireContact={Boolean(session.require_contact)}
+      />
 
       <div className="mt-6 space-y-3 border-t pt-4">
         <p className="text-sm font-medium text-gray-700">Admin actions</p>

--- a/src/components/RSVPControls.tsx
+++ b/src/components/RSVPControls.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type ResponseStatus = "in" | "out" | "maybe";
+
+type ContactPreference = "email" | "phone" | null;
+
+type SessionResponse = {
+  player_name: string;
+  email: string | null;
+  phone_whatsapp: string | null;
+  preferred_contact: ContactPreference;
+  status: ResponseStatus | null;
+};
+
+type RSVPControlsProps = {
+  sessionId: string;
+  initialResponse: SessionResponse | null;
+  requireContact?: boolean;
+};
+
+type StoredResponse = {
+  playerName: string;
+  email: string;
+  phone: string;
+  status: ResponseStatus | null;
+  preferredContact: ContactPreference;
+};
+
+const storageKeyFor = (sessionId: string) => `session:${sessionId}:rsvp`;
+
+function parseStoredResponse(value: string | null): StoredResponse | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Partial<StoredResponse>;
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    return {
+      playerName: typeof parsed.playerName === "string" ? parsed.playerName : "",
+      email: typeof parsed.email === "string" ? parsed.email : "",
+      phone: typeof parsed.phone === "string" ? parsed.phone : "",
+      status:
+        parsed.status === "in" || parsed.status === "out" || parsed.status === "maybe"
+          ? parsed.status
+          : null,
+      preferredContact:
+        parsed.preferredContact === "email" || parsed.preferredContact === "phone"
+          ? parsed.preferredContact
+          : null,
+    } satisfies StoredResponse;
+  } catch (error) {
+    console.warn("Could not parse stored RSVP response", error);
+    return null;
+  }
+}
+
+export default function RSVPControls({
+  sessionId,
+  initialResponse,
+  requireContact = false,
+}: RSVPControlsProps) {
+  const [hydrated, setHydrated] = useState(false);
+  const [playerName, setPlayerName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [status, setStatus] = useState<ResponseStatus | null>(null);
+  const [preferredContact, setPreferredContact] = useState<ContactPreference>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const storageKey = useMemo(() => storageKeyFor(sessionId), [sessionId]);
+
+  useEffect(() => {
+    const stored = parseStoredResponse(
+      typeof window !== "undefined" ? window.localStorage.getItem(storageKey) : null,
+    );
+
+    if (stored) {
+      setPlayerName(stored.playerName ?? "");
+      setEmail(stored.email ?? "");
+      setPhone(stored.phone ?? "");
+      setStatus(stored.status ?? null);
+      setPreferredContact(stored.preferredContact ?? null);
+    } else if (initialResponse) {
+      setPlayerName(initialResponse.player_name ?? "");
+      setEmail(initialResponse.email ?? "");
+      setPhone(initialResponse.phone_whatsapp ?? "");
+      setStatus(initialResponse.status ?? null);
+      setPreferredContact(initialResponse.preferred_contact ?? null);
+    }
+
+    setHydrated(true);
+  }, [initialResponse, storageKey]);
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+
+    const payload: StoredResponse = {
+      playerName,
+      email,
+      phone,
+      status,
+      preferredContact,
+    };
+
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(payload));
+    } catch (error) {
+      console.warn("Unable to persist RSVP response", error);
+    }
+  }, [email, phone, playerName, preferredContact, status, storageKey, hydrated]);
+
+  const confirmationMessage = useMemo(() => {
+    if (status === "in") {
+      return "✅ You’re in!";
+    }
+    if (status === "out") {
+      return "☑️ You’re out for now.";
+    }
+    if (status === "maybe") {
+      return "🤔 You’re a maybe.";
+    }
+    return null;
+  }, [status]);
+
+  const handleSubmit = useCallback(
+    async (nextStatus: ResponseStatus) => {
+      const trimmedName = playerName.trim();
+      const trimmedEmail = email.trim();
+      const trimmedPhone = phone.trim();
+      const contactPreference: ContactPreference = trimmedEmail
+        ? "email"
+        : trimmedPhone
+        ? "phone"
+        : null;
+
+      if (!trimmedName) {
+        setError("Please enter your name to RSVP.");
+        return;
+      }
+
+      if (requireContact && !trimmedEmail && !trimmedPhone) {
+        setError("Please add an email or WhatsApp number so we can reach you.");
+        return;
+      }
+
+      setPending(true);
+      setError(null);
+
+      try {
+        const response = await fetch(`/api/sessions/${sessionId}/rsvp`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            playerName: trimmedName,
+            email: trimmedEmail || null,
+            phone: trimmedPhone || null,
+            preferredContact: contactPreference,
+            status: nextStatus,
+          }),
+        });
+
+        if (!response.ok) {
+          const result = (await response.json().catch(() => null)) as
+            | { message?: string }
+            | null;
+          throw new Error(result?.message ?? "Unable to save your response. Please try again.");
+        }
+
+        setStatus(nextStatus);
+        setPreferredContact(contactPreference);
+      } catch (error) {
+        if (error instanceof Error) {
+          setError(error.message);
+        } else {
+          setError("Something went wrong. Please try again.");
+        }
+      } finally {
+        setPending(false);
+      }
+    },
+    [email, phone, playerName, requireContact, sessionId],
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700" htmlFor="rsvp-name">
+          Your name
+        </label>
+        <input
+          id="rsvp-name"
+          className="w-full rounded-xl border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+          placeholder="Jane Doe"
+          value={playerName}
+          onChange={(event) => setPlayerName(event.target.value)}
+          disabled={pending}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700" htmlFor="rsvp-email">
+          Email (optional)
+        </label>
+        <input
+          id="rsvp-email"
+          type="email"
+          className="w-full rounded-xl border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          disabled={pending}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700" htmlFor="rsvp-phone">
+          WhatsApp (optional)
+        </label>
+        <input
+          id="rsvp-phone"
+          className="w-full rounded-xl border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+          placeholder="+1 555 123 4567"
+          value={phone}
+          onChange={(event) => setPhone(event.target.value)}
+          disabled={pending}
+        />
+      </div>
+
+      {requireContact ? (
+        <p className="text-xs text-gray-500">
+          We need at least one contact method so we can follow up if plans change.
+        </p>
+      ) : null}
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        {(
+          [
+            { label: "I’m in", value: "in" },
+            { label: "I’m out", value: "out" },
+            { label: "Maybe", value: "maybe" },
+          ] as const
+        ).map(({ label, value }) => {
+          const isActive = status === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => handleSubmit(value)}
+              disabled={pending}
+              className={`flex-1 rounded-xl border px-4 py-3 text-center text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+                isActive
+                  ? value === "in"
+                    ? "border-green-600 bg-green-50 text-green-700 focus:ring-green-500"
+                    : value === "out"
+                    ? "border-red-500 bg-red-50 text-red-600 focus:ring-red-500"
+                    : "border-yellow-500 bg-yellow-50 text-yellow-600 focus:ring-yellow-500"
+                  : "border-gray-300 text-gray-700 hover:border-gray-400 focus:ring-blue-500"
+              } ${pending ? "opacity-70" : ""}`}
+            >
+              {pending && status !== value ? `${label}…` : label}
+            </button>
+          );
+        })}
+      </div>
+
+      {confirmationMessage ? (
+        <div className="rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+          {confirmationMessage}
+        </div>
+      ) : null}
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- load session data on the RSVP page, include existing responses, and hand off to a new RSVPControls client component
- build RSVPControls to manage local state, persist to localStorage, and post RSVP updates without reloading
- add an RSVP API route that upserts session responses and stores a contact cookie for subsequent visits

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c6c5e1388320b125b30bc54f919f