### PR TITLE
Add enum type creation for session responses migration

### DIFF
--- a/supabase/migrations/20250110120000_create_session_responses.sql
+++ b/supabase/migrations/20250110120000_create_session_responses.sql
@@ -1,5 +1,9 @@
 create extension if not exists "uuid-ossp";
 
+create type if not exists contact_type as enum ('email', 'phone_whatsapp');
+
+create type if not exists response_status as enum ('in', 'out', 'maybe');
+
 create table if not exists public.session_responses (
   id uuid primary key default uuid_generate_v4(),
   session_id uuid not null references public.sessions(id) on delete cascade,


### PR DESCRIPTION
## Summary
- add create type statements for the contact and status enums in the session responses migration so the table can be created

## Testing
- not run (Supabase CLI unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6ab65f42c8320b9536513e8aa56c2