### PR TITLE
Validate RSVP enums on API requests

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,16 @@
-export type ContactType = "email" | "phone_whatsapp" | (string & {});
+export const CONTACT_TYPES = ["email", "phone_whatsapp"] as const;
+export type ContactType = (typeof CONTACT_TYPES)[number];
 
-export type ResponseStatus = "in" | "out" | "maybe" | (string & {});
+export const RESPONSE_STATUSES = ["in", "out", "maybe"] as const;
+export type ResponseStatus = (typeof RESPONSE_STATUSES)[number];
+
+export function isContactType(value: string): value is ContactType {
+  return (CONTACT_TYPES as readonly string[]).includes(value);
+}
+
+export function isResponseStatus(value: string): value is ResponseStatus {
+  return (RESPONSE_STATUSES as readonly string[]).includes(value);
+}
 
 export type SessionResponse = {
   id: string;


### PR DESCRIPTION
## Summary
- reject RSVP payloads that provide unsupported preferred contact or status values
- surface specific 400 responses for invalid enum values before attempting Supabase writes
- export shared RSVP enum constants and type guards for client-side validation reuse

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d783b8868083208ab8148eb3d43318